### PR TITLE
Validate keys

### DIFF
--- a/apps/billsplit/billsplit_db.py
+++ b/apps/billsplit/billsplit_db.py
@@ -8,7 +8,7 @@ from keys import KEYS
 import texts
 
 
-deta_client = deta.Deta(KEYS["Deta"]["project_key"])
+deta_client = deta.Deta(KEYS.Deta.project_key)
 db = deta_client.Base("billsplit")
 
 

--- a/apps/gpt/agency.py
+++ b/apps/gpt/agency.py
@@ -10,7 +10,7 @@ from . import prompts
 
 # ---- Build the agent ----
 
-llm = ChatOpenAI(model_name="gpt-4", openai_api_key=KEYS["OpenAI"]["api_key"], temperature=0)
+llm = ChatOpenAI(model_name="gpt-4", openai_api_key=KEYS.OpenAI.api_key, temperature=0)
 
 def create_agent_executor(toolkit: list[Tool]) -> AgentExecutor:
     """Create the agent given authenticated tools."""

--- a/apps/gpt/completions.py
+++ b/apps/gpt/completions.py
@@ -5,7 +5,7 @@ from keys import KEYS
 
 
 # Authennticate OpenAI
-openai.api_key = KEYS["OpenAI"]["api_key"]
+openai.api_key = KEYS.OpenAI.api_key
 
 
 def gpt_response(prompt: str) -> str:

--- a/apps/gpt/make_calls/call_tool.py
+++ b/apps/gpt/make_calls/call_tool.py
@@ -23,7 +23,7 @@ def make_call(recipient: str, goal: str, recipient_desc: str) -> str:
     call_params: dict[str, str] = {"call_id": created_call.key}
     outbound_call = twilio_client.calls.create(
         recipient,
-        KEYS["Twilio"]["sender"],
+        KEYS.Twilio.sender,
         url=f"{BASE_URL}/voice/outbound/handler?{urlencode(call_params)}",
         record=True
     )

--- a/apps/gpt/make_calls/database.py
+++ b/apps/gpt/make_calls/database.py
@@ -5,7 +5,7 @@ from keys import KEYS
 import voice_tools as vt
 
 
-deta_client = deta.Deta(KEYS["Deta"]["project_key"])
+deta_client = deta.Deta(KEYS.Deta.project_key)
 convo_base = deta_client.Base("conversations")
 
 

--- a/apps/gpt/make_calls/prompts/__init__.py
+++ b/apps/gpt/make_calls/prompts/__init__.py
@@ -11,7 +11,7 @@ from keys import KEYS
 
 
 llm = ChatOpenAI(
-    openai_api_key=KEYS["OpenAI"]["api_key"], 
+    openai_api_key=KEYS.OpenAI.api_key, 
     model_name="gpt-3.5-turbo", 
     temperature=0
 )

--- a/apps/gpt/news.py
+++ b/apps/gpt/news.py
@@ -36,7 +36,7 @@ def _headline_news(category: str) -> Articles:
     """Query directly and return URLs, titles, and contents."""
     res = requests.get(
         f"{NEWS_ENDPOINT}/top-headlines",
-        params={"apiKey": KEYS["NewsAPI"]["api_key"], "country": "us", "category": category},
+        params={"apiKey": KEYS.NewsAPI.api_key, "country": "us", "category": category},
     )
 
     articles = res.json()["articles"]

--- a/apps/gpt/retrieval.py
+++ b/apps/gpt/retrieval.py
@@ -17,8 +17,8 @@ import utils
 from keys import KEYS
 
 
-llm = ChatOpenAI(model_name="gpt-4", openai_api_key=KEYS["OpenAI"]["api_key"], temperature=0)
-embeddings = OpenAIEmbeddings(openai_api_key=KEYS["OpenAI"]["api_key"])
+llm = ChatOpenAI(model_name="gpt-4", openai_api_key=KEYS.OpenAI.api_key, temperature=0)
+embeddings = OpenAIEmbeddings(openai_api_key=KEYS.OpenAI.api_key)
 N_DOCS = 5  # 10 for gpt-4, 5 for 3.5
 splitter = TokenTextSplitter(
     encoding_name="cl100k_base", 
@@ -28,7 +28,7 @@ splitter = TokenTextSplitter(
 
 
 # Deta Base for caching conversions
-deta_client = deta.Deta(KEYS["Deta"]["project_key"])
+deta_client = deta.Deta(KEYS.Deta.project_key)
 conversions_db = deta_client.Base("conversions_cache")
 
 
@@ -139,7 +139,7 @@ class YouTubeAnswerer(BaseAnswerer):
 
         # Then get the transcript
         response = requests.post(
-            f'{KEYS["Transcription"]["api_url"]}/youtube',
+            f'{KEYS.Transcription.api_url}/youtube',
             json={"video_id": video_id}
         )
 

--- a/apps/gpt/tool_auth.py
+++ b/apps/gpt/tool_auth.py
@@ -58,7 +58,7 @@ ANSWERER_JSON_STRING_INPUT_INSTRUCTIONS = (
 no_auth_tools = [
     Tool(
         name="Google Search",
-        func=GoogleSerperAPIWrapperURL(serper_api_key=KEYS["GoogleSerper"]["api_key"]).run,
+        func=GoogleSerperAPIWrapperURL(serper_api_key=KEYS.GoogleSerper.api_key).run,
         description=(
             "Useful for when you need to search Google. Provides links to search results "
             "that you can use Website Answerer to answer for more information."
@@ -95,7 +95,7 @@ no_auth_tools = [
     ),
     Tool(
         name="Wolfram Alpha",
-        func=WolframAlphaAPIWrapper(wolfram_alpha_appid=KEYS["WolframAlpha"]["app_id"]).run,
+        func=WolframAlphaAPIWrapper(wolfram_alpha_appid=KEYS.WolframAlpha.app_id).run,
         description=(
             "Useful for when you need to do math or anything quantitative/computational. "
             "Input should ideally be math expressions, ex. \"8^3\", but can also be "
@@ -111,8 +111,8 @@ def build_tools(inbound_phone: str) -> list[Tool]:
     added_tools = []
 
     # Zapier
-    if inbound_phone in KEYS["ZapierNLA"]:
-        zapier_key = KEYS["ZapierNLA"][inbound_phone]
+    if inbound_phone in KEYS.ZapierNLA:
+        zapier_key = KEYS.ZapierNLA[inbound_phone]
         zapier_wrapper = ZapierNLAWrapper(zapier_nla_api_key=zapier_key)
         zapier_toolkit = ZapierToolkit.from_zapier_nla_wrapper(zapier_wrapper)
         added_tools.extend(zapier_toolkit.get_tools())

--- a/apps/jokes/__init__.py
+++ b/apps/jokes/__init__.py
@@ -16,7 +16,7 @@ def random_joke(tags: str):
         endpoint,
         params = {
             "include-tags": tags,
-            "api-key": KEYS["HumorAPI"]["api_key"]
+            "api-key": KEYS.HumorAPI.api_key
         }
     )
 

--- a/apps/weather/data.py
+++ b/apps/weather/data.py
@@ -45,7 +45,7 @@ def current_weather(
         WEATHER_ENDPOINT, 
         {
             "q": ",".join([ele for ele in [city.lower(), state.lower(), country.lower()] if ele]), 
-            "appid": KEYS["OpenWeatherMap"]["api_key"]
+            "appid": KEYS.OpenWeatherMap.api_key
         }
     )
 

--- a/keys.py
+++ b/keys.py
@@ -15,3 +15,10 @@ if not os.path.exists(keys_path):
 
 with open(keys_path, "r") as f:
     KEYS = yaml.safe_load(f)
+
+
+# ---- Parsing ----
+
+MANIFEST = {
+    
+}

--- a/keys/__init__.py
+++ b/keys/__init__.py
@@ -4,9 +4,12 @@ Read keys.yaml.
 import os
 import yaml
 
+from keys import models
+
 
 keys_path = os.path.join(
     (current_dir := os.path.realpath(os.path.dirname(__file__))),
+    "..",  # parent dir since module is in a subdirectory
     "keys.yaml"
 )
 
@@ -14,11 +17,8 @@ if not os.path.exists(keys_path):
     raise FileNotFoundError("keys.yaml file not found.")
 
 with open(keys_path, "r") as f:
-    KEYS = yaml.safe_load(f)
+    RAW_KEYS = yaml.safe_load(f)
 
 
-# ---- Parsing ----
-
-MANIFEST = {
-    
-}
+# Validate the keys and expose KEYS
+KEYS = models.Keys(**RAW_KEYS)

--- a/keys/models.py
+++ b/keys/models.py
@@ -1,0 +1,163 @@
+"""
+This module defines Pydantic models for validating a YAML configuration file containing API keys and settings
+for various services such as Twilio, Deta, HumorAPI, OpenWeatherMap, OpenAI, GoogleSerper, WolframAlpha,
+NewsAPI, ElevenLabs, UploadIO, and Transcription.
+"""
+from pydantic import BaseModel
+
+
+class TwilioModel(BaseModel):
+    """
+    A Pydantic model for Twilio configurations.
+
+    Attributes:
+        account_sid (str): The Twilio account SID.
+        auth_token (str): The Twilio authentication token.
+        sender (str): The Twilio sender phone number.
+        sender_sid (str): The Twilio sender SID.
+        my_number (str): Your Twilio phone number.
+    """
+    account_sid: str
+    auth_token: str
+    sender: str
+    sender_sid: str
+    my_number: str
+
+
+class DetaModel(BaseModel):
+    """
+    A Pydantic model for Deta configurations.
+
+    Attributes:
+        project_key (str): The Deta project key.
+    """
+    project_key: str
+
+
+class HumorAPIModel(BaseModel):
+    """
+    A Pydantic model for HumorAPI configurations.
+
+    Attributes:
+        api_key (str): The HumorAPI key.
+    """
+    api_key: str
+
+
+class OpenWeatherMapModel(BaseModel):
+    """
+    A Pydantic model for OpenWeatherMap configurations.
+
+    Attributes:
+        api_key (str): The OpenWeatherMap API key.
+    """
+    api_key: str
+
+
+class OpenAIModel(BaseModel):
+    """
+    A Pydantic model for OpenAI configurations.
+
+    Attributes:
+        api_key (str): The OpenAI API key.
+    """
+    api_key: str
+
+
+class GoogleSerperModel(BaseModel):
+    """
+    A Pydantic model for GoogleSerper configurations.
+
+    Attributes:
+        api_key (str): The GoogleSerper API key.
+    """
+    api_key: str
+
+
+class WolframAlphaModel(BaseModel):
+    """
+    A Pydantic model for WolframAlpha configurations.
+
+    Attributes:
+        app_id (str): The WolframAlpha App ID.
+    """
+    app_id: str
+
+
+class NewsAPIModel(BaseModel):
+    """
+    A Pydantic model for NewsAPI configurations.
+
+    Attributes:
+        api_key (str): The NewsAPI API key.
+    """
+    api_key: str
+
+
+class ElevenLabsModel(BaseModel):
+    """
+    A Pydantic model for ElevenLabs configurations.
+
+    Attributes:
+        api_key (str): The ElevenLabs API key.
+        voice_id (str): The ElevenLabs voice ID.
+    """
+    api_key: str
+    voice_id: str
+
+
+class UploadIOModel(BaseModel):
+    """
+    A Pydantic model for UploadIO configurations.
+
+    Attributes:
+        account (str): The UploadIO account ID.
+        api_key (str): The UploadIO API key.
+    """
+    account: str
+    api_key: str
+
+
+class TranscriptionModel(BaseModel):
+    """
+    A Pydantic model for Transcription configurations.
+
+    Attributes:
+        api_url (str): The Transcription API URL.
+    """
+    api_url: str
+
+
+class Keys(BaseModel):
+    """
+    A Pydantic model for validating all API keys configurations.
+
+    Attributes:
+        Twilio (TwilioModel): The Twilio configuration model.
+        Deta (DetaModel): The Deta configuration model.
+        HumorAPI (HumorAPIModel): The HumorAPI configuration model.
+        OpenWeatherMap (OpenWeatherMapModel): The OpenWeatherMap configuration model.
+        OpenAI (OpenAIModel): The OpenAI configuration model.
+        GoogleSerper (GoogleSerperModel): The GoogleSerper configuration model.
+        ZapierNLA (Dict[str, str]): A dictionary containing phone numbers as keys and API keys as values.
+        WolframAlpha (WolframAlphaModel): The WolframAlpha configuration model.
+        NewsAPI (NewsAPIModel): The NewsAPI configuration model.
+        ElevenLabs (ElevenLabsModel): The ElevenLabs configuration model.
+        UploadIO (UploadIOModel): The UploadIO configuration model.
+        Transcription (TranscriptionModel): The Transcription configuration model.
+    """
+    # Required keys (tests and active applets)
+    Twilio: TwilioModel
+    Deta: DetaModel
+    HumorAPI: HumorAPIModel
+    OpenWeatherMap: OpenWeatherMapModel
+    OpenAI: OpenAIModel
+    GoogleSerper: GoogleSerperModel
+    WolframAlpha: WolframAlphaModel
+    ElevenLabs: ElevenLabsModel
+    UploadIO: UploadIOModel
+    Transcription: TranscriptionModel
+
+    # Optional keys (Optional features and inactive applets/features)
+    ZapierNLA: dict[str, str] | None
+    NewsAPI: NewsAPIModel | None

--- a/permissions.py
+++ b/permissions.py
@@ -8,7 +8,7 @@ import deta
 from keys import KEYS
 
 
-deta_client = deta.Deta(KEYS["Deta"]["project_key"])
+deta_client = deta.Deta(KEYS.Deta.project_key)
 permissions_db = deta_client.Base("permissions")
 
 
@@ -23,7 +23,7 @@ def db_init() -> str:
     db_res: dict = permissions_db.put(
         {
             "Name": "Prerit Das",
-            "Phone": KEYS["Twilio"]["my_number"],
+            "Phone": KEYS.Twilio.my_number,
             "Permissions": "all"
         }
     )

--- a/tests/test_app_invite.py
+++ b/tests/test_app_invite.py
@@ -49,7 +49,7 @@ def test_inviting(mocker, default_options):
 
 def test_failed_delivery(mocker, default_options):
     """Mock a bad API key."""
-    mocker.patch("texts.twilio_client", Client(KEYS["Twilio"]["account_sid"], "invalid"))
+    mocker.patch("texts.twilio_client", Client(KEYS.Twilio.account_sid, "invalid"))
 
     with pytest.raises(TwilioRestException):
         invite.handler("14259023246", default_options)

--- a/texts.py
+++ b/texts.py
@@ -10,8 +10,8 @@ import config
 
 
 twilio_client = TwilioClient(
-    KEYS["Twilio"]["account_sid"],
-    KEYS["Twilio"]["auth_token"]
+    KEYS.Twilio.account_sid,
+    KEYS.Twilio.auth_token
 )
 
 
@@ -25,7 +25,7 @@ def extract_base_url(url: str) -> str:
 
 # Get the deployed base url. Currently not needed as using UploadIO.
 BASE_URL = extract_base_url(
-    twilio_client.incoming_phone_numbers.get(KEYS["Twilio"]["sender_sid"]).fetch().voice_url
+    twilio_client.incoming_phone_numbers.get(KEYS.Twilio.sender_sid).fetch().voice_url
 )
 
 
@@ -40,7 +40,7 @@ def send_message(content: str, recipient: str) -> bool:
 
     message_sent = twilio_client.messages.create(
         to = recipient,
-        from_ = KEYS["Twilio"]["sender"],
+        from_ = KEYS.Twilio.sender,
         body = content
     )
 

--- a/usage.py
+++ b/usage.py
@@ -12,7 +12,7 @@ from keys import KEYS
 import config
 
 
-deta = deta.Deta(KEYS["Deta"]["project_key"])
+deta = deta.Deta(KEYS.Deta.project_key)
 usage_db = deta.Base("usage")
 permissions_db = deta.Base("permissions")
 

--- a/voice_tools/speak.py
+++ b/voice_tools/speak.py
@@ -9,14 +9,14 @@ from keys import KEYS
 from . import speech_cache
 
 
-JEEVES_VOICE_ID = KEYS["ElevenLabs"]["voice_id"]
+JEEVES_VOICE_ID = KEYS.ElevenLabs.voice_id
 
 
 def _upload_result(filepath: str) -> str:
     """Upload the result to the server and return the URL."""
-    url = f"https://api.upload.io/v2/accounts/{KEYS['UploadIO']['account']}/uploads/binary"
+    url = f"https://api.upload.io/v2/accounts/{KEYS.UploadIO.account}/uploads/binary"
     headers = {
-        "Authorization": f"Bearer {KEYS['UploadIO']['api_key']}",
+        "Authorization": f"Bearer {KEYS.UploadIO.api_key}",
         "Content-Type": "audio/mpeg"
     }
 
@@ -33,7 +33,7 @@ def speak_jeeves(text: str) -> str:
     if (cached_url := speech_cache.get_speech(text)):
         return cached_url
 
-    byte_code = elevenlabs.generate(text, KEYS["ElevenLabs"]["api_key"], JEEVES_VOICE_ID)
+    byte_code = elevenlabs.generate(text, KEYS.ElevenLabs.api_key, JEEVES_VOICE_ID)
     filepath = f"{uuid.uuid1()}.mp3"
 
     with open(filepath, "wb") as f:

--- a/voice_tools/speech_cache.py
+++ b/voice_tools/speech_cache.py
@@ -4,7 +4,7 @@ import deta
 from keys import KEYS
 
 
-deta_client = deta.Deta(KEYS["Deta"]["project_key"])
+deta_client = deta.Deta(KEYS.Deta.project_key)
 speech_db = deta_client.Base("voice_cache")
 
 
@@ -12,7 +12,7 @@ def cache_speech(text: str, url: str) -> None:
     """Cache the speech."""
     speech_db.put(
         {
-            "Voice": KEYS["ElevenLabs"]["voice_id"],
+            "Voice": KEYS.ElevenLabs.voice_id,
             "Text": text,
             "URL": url
         }
@@ -24,7 +24,7 @@ def get_speech(text: str) -> str:
     items = speech_db.fetch(
         query={
             "Text": text,
-            "Voice": KEYS["ElevenLabs"]["voice_id"]
+            "Voice": KEYS.ElevenLabs.voice_id
         }
     ).items
 

--- a/voice_tools/transcribe.py
+++ b/voice_tools/transcribe.py
@@ -31,7 +31,7 @@ def _whisper_transcribe_url(url: str) -> str:
     remote_file.raise_for_status()
 
     # OpenAI information
-    headers = {"Authorization": f"Bearer {KEYS['OpenAI']['api_key']}"}
+    headers = {"Authorization": f"Bearer {KEYS.OpenAI.api_key}"}
     data = {"model": "whisper-1"}
     files = {"file": ("audio.mp3", remote_file.raw, "multipart/form-data")}
 


### PR DESCRIPTION
Validating keys has numerous benefits.

1. Manifest - makes it clear what keys are required, what values for each provider are required, and what the variable names should be inside a `keys.yaml` file.
2. Validation - makes sure the values provided are given in the correct format, and if not, convert them if possible so they can be used as expected throughout.
3. Nicer interface throughout - allows for attribute-style calling of keys, ex. `KEYS.OpenAI.api_key` instead of `KEYS["OpenAI"]["api_key"]`. Autocomplete and IDE hints will display all available keys, attributes, and their types to make mistakes far less common.