### PR TITLE
Improve test coverage

### DIFF
--- a/api/text_inbound.py
+++ b/api/text_inbound.py
@@ -40,5 +40,4 @@ def main_handler_wrapper(From: str = Form(...), Body: str = Form(...)):
 
     # Process the request
     route_to_handler(inbound_model)
-
     return ""

--- a/api/voice_inbound.py
+++ b/api/voice_inbound.py
@@ -30,6 +30,8 @@ def speak(response: VoiceResponse, text: str) -> None:
     uses ElevenLabs to speak the text, uses UploadIO to upload the mp3 file and get
     a public-facing audio URL, then adds a <Play> tag to the repsonse object
     containing that public URL.
+
+    Returns nothing because the VoiceResponse object is modified in-place.
     """
     speech_url = vt.speak.speak_jeeves(text)
     response.play(speech_url)

--- a/apps/gpt/make_calls/call_tool.py
+++ b/apps/gpt/make_calls/call_tool.py
@@ -14,14 +14,12 @@ from texts import twilio_client, BASE_URL
 
 # Make calls
 from apps.gpt.make_calls import database as db
-from apps.gpt.make_calls import prompts
 
 
 def make_call(recipient: str, goal: str, recipient_desc: str) -> str:
     """Makes the call and returns a transcript."""
     created_call = db.Call.create(
         goal=goal,
-        greeting=prompts.generate_intro_message(goal, recipient_desc),
         recipient_desc=recipient_desc
     )
 

--- a/apps/gpt/make_calls/database.py
+++ b/apps/gpt/make_calls/database.py
@@ -86,3 +86,7 @@ class Call:
             call = convo_base.get(call_id)
 
         return cls(**call)
+
+    def delete(self) -> None:
+        """Delete the call record from the database."""
+        convo_base.delete(self.key)

--- a/apps/gpt/make_calls/database.py
+++ b/apps/gpt/make_calls/database.py
@@ -4,6 +4,8 @@ import deta
 from keys import KEYS
 import voice_tools as vt
 
+from apps.gpt.make_calls.prompts import generate_intro_message
+
 
 deta_client = deta.Deta(KEYS.Deta.project_key)
 convo_base = deta_client.Base("conversations")
@@ -54,8 +56,11 @@ class Call:
         self.__dict__.update(call)
 
     @classmethod
-    def create(cls, goal: str, greeting: str, recipient_desc: str) -> "Call":
+    def create(cls, goal: str, recipient_desc: str) -> "Call":
         """Create a call."""
+        # Create the greeting
+        greeting = generate_intro_message(goal, recipient_desc)
+
         attrs = {
             "convo": "",
             "goal": goal,

--- a/apps/gpt/make_calls/routes.py
+++ b/apps/gpt/make_calls/routes.py
@@ -30,10 +30,8 @@ def speak(response: VoiceResponse, text: str) -> None:
     response.play(speech_url)
 
 
-def update_call_with_response(call_id: str, call_sid: str, user_speech: str) -> None:
-    """
-    Generate a response and update the call with that response.
-    """
+def process_user_speech(call_id: str, call_sid: str, user_speech: str) -> VoiceResponse:
+    """Generate a VoiceResponse based on the user's speech."""
     response = VoiceResponse()
 
     # Setup the conversation
@@ -65,6 +63,15 @@ def update_call_with_response(call_id: str, call_sid: str, user_speech: str) -> 
 
     # Update the conversation record
     current_call.upload()
+
+    return response
+
+
+def update_call_with_response(call_id: str, call_sid: str, user_speech: str) -> None:
+    """
+    Generate a response and update the call with that response.
+    """
+    response = process_user_speech(call_id, call_sid, user_speech)
 
     # Update the call, ignore if the recipient hung up
     try:

--- a/apps/gpt/make_calls/routes.py
+++ b/apps/gpt/make_calls/routes.py
@@ -30,7 +30,7 @@ def speak(response: VoiceResponse, text: str) -> None:
     response.play(speech_url)
 
 
-def process_user_speech(call_id: str, call_sid: str, user_speech: str) -> VoiceResponse:
+def process_user_speech(call_id: str, user_speech: str) -> VoiceResponse:
     """Generate a VoiceResponse based on the user's speech."""
     response = VoiceResponse()
 

--- a/apps/gpt/news.py
+++ b/apps/gpt/news.py
@@ -59,7 +59,7 @@ def get_headline_news(category: str) -> str:
 
 ## ---- Manual ----
 
-def manual_headline_news(category: str) -> str:
+def _manual_headline_news(category: str) -> str:
     """Manually get headline news by using a WebsiteAnswerer."""
     category = category.strip().lower()
 
@@ -78,3 +78,11 @@ def manual_headline_news(category: str) -> str:
         ),
         n_docs=20
     )
+
+
+def manual_headline_news(category: str) -> str:
+    """Manually get headline news, catch errors and return a string."""
+    try:
+        return _manual_headline_news(category)
+    except Exception as e:
+        return f"Error getting headline news: {e}"

--- a/apps/gpt/send_texts.py
+++ b/apps/gpt/send_texts.py
@@ -7,7 +7,7 @@ from typing import Any, Coroutine
 import texts
 
 
-def create_text_message_tool(inbound_phone: str) -> BaseTool:
+def create_text_message_tool(inbound_phone: str) -> type[BaseTool]:
     """
     Create a tool to send text messages.
 

--- a/apps/gpt/send_texts.py
+++ b/apps/gpt/send_texts.py
@@ -56,7 +56,7 @@ def create_text_message_tool(inbound_phone: str) -> type[BaseTool]:
                     recipient=inbound_phone,
                 )
 
-            return send_res
+            return str(send_res)
 
         def _arun(self, *args: Any, **kwargs: Any) -> Coroutine[Any, Any, str]:
             raise NotImplementedError(f"{type(self).__name__} does not support async.")

--- a/apps/gpt/tool_auth.py
+++ b/apps/gpt/tool_auth.py
@@ -1,5 +1,6 @@
 """Load tools depending on authorization."""
 from langchain.agents import Tool
+from langchain.tools import BaseTool
 from langchain.utilities import GoogleSerperAPIWrapper
 from langchain.utilities.wolfram_alpha import WolframAlphaAPIWrapper
 from langchain.utilities.zapier import ZapierNLAWrapper
@@ -55,7 +56,7 @@ ANSWERER_JSON_STRING_INPUT_INSTRUCTIONS = (
     "Input must be a JSON string with the keys \"source\" and \"query\"."
 )
 
-no_auth_tools = [
+no_auth_tools: list[BaseTool] = [
     Tool(
         name="Google Search",
         func=GoogleSerperAPIWrapperURL(serper_api_key=KEYS.GoogleSerper.api_key).run,

--- a/keys/models.py
+++ b/keys/models.py
@@ -159,5 +159,5 @@ class Keys(BaseModel):
     Transcription: TranscriptionModel
 
     # Optional keys (Optional features and inactive applets/features)
-    ZapierNLA: dict[str, str] | None
-    NewsAPI: NewsAPIModel | None
+    ZapierNLA: dict[str, str] = {}
+    NewsAPI: NewsAPIModel  = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,9 @@ def default_inbound() -> dict[str, str]:
         [str(random.choice([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])) for _ in range(10)]
     )
 
+    # Add US country code
+    random_inbound = "1" + random_inbound
+
     return {
         "phone_number": random_inbound,
         "body": "app: apps",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,8 @@ import random
 import usage  # fixture for temporary logs for report
 import permissions  # fixtures for temporary users
 
+from apps.gpt.make_calls.database import Call
+
 
 @pytest.fixture(scope="session")
 def default_inbound() -> dict[str, str]:
@@ -135,9 +137,28 @@ def temp_usage_logs():
 
 
 @pytest.fixture
-def who_are_you_twilio_recording():
+def who_are_you_twilio_recording() -> str:
     """Twilio audio recording asking 'who are you?'"""
     return (
         "https://api.twilio.com/2010-04-01/Accounts/ACe84ee0dbced3a3132211427153ae959a"
         "/Recordings/REed31c6f0df039c1d98b23288ae87fc73"
     )
+
+
+@pytest.fixture(scope="session")
+def outbound_call_key() -> str:
+    """Call ID for outbound call."""
+    call = Call.create(
+        recipient_desc="Epic Restaurant",
+        goal="Make a reservation for 2 people at 7pm on Friday"
+    )
+
+    # Add the greeting to the conversation as if it was spoken
+    # the handler does this automatically
+    call.convo += f"Jeeves: {call.greeting}"
+    call.upload()
+
+    yield call.key
+
+    # Remove the temporary call
+    call.delete()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -132,3 +132,12 @@ def temp_usage_logs():
     # Remove the temporary logs
     for key in keys:
         usage.usage_db.delete(key)
+
+
+@pytest.fixture
+def who_are_you_twilio_recording():
+    """Twilio audio recording asking 'who are you?'"""
+    return (
+        "https://api.twilio.com/2010-04-01/Accounts/ACe84ee0dbced3a3132211427153ae959a"
+        "/Recordings/REed31c6f0df039c1d98b23288ae87fc73"
+    )

--- a/tests/test_app_gpt.py
+++ b/tests/test_app_gpt.py
@@ -65,7 +65,7 @@ def test_processing_speech_outbound(outbound_call_key):
     assert voice_response
     assert (xml := voice_response.to_xml())
     assert "Play" in xml
-    assert "uploadio" in xml
+    assert "upcdn" in xml
     
 
 def test_serper_wrapper():

--- a/tests/test_app_gpt.py
+++ b/tests/test_app_gpt.py
@@ -1,18 +1,18 @@
 "Test the GPT app."
-# import pytest
+import pytest
 
-from apps import gpt
+from apps.gpt import handler
+from api.voice_inbound import _process_speech
 
 
-# @pytest.mark.xfail
 def test_handler(default_options):
     """Test the GPT applet handler."""
     # Use vanilla GPT
     default_options["agency"] = "no"
 
-    res = gpt.handler(
-        content = "Give me three short rhyming words.",
-        options = default_options
+    res = handler(
+        content="Give me three short rhyming words.",
+        options=default_options
     )
 
     assert res
@@ -21,11 +21,28 @@ def test_handler(default_options):
 
 def test_agency(default_options):
     """Test the GPT applet handler."""
-    res = gpt.handler(
-        content = "Who are you?",
-        options = default_options
+    res = handler(
+        content="Who are you?",
+        options=default_options
     )
 
     assert res
     assert isinstance(res, str)
     assert "Jeeves" in res
+
+
+@pytest.mark.xfail(reason="Out of ElevenLabs credits.")
+def test_processing_speech(who_are_you_twilio_recording, default_options):
+    """
+    Test the background process that updates the call with a response when calling 
+    Jeeves (inbound).
+    """
+    response = _process_speech(
+        inbound_phone=default_options["inbound_phone"],
+        audio_url=who_are_you_twilio_recording
+    )
+
+    assert response
+    assert (xml := response.to_xml())
+    assert "Play" in xml
+    assert "uploadio" in xml

--- a/tests/test_app_gpt.py
+++ b/tests/test_app_gpt.py
@@ -5,6 +5,7 @@ from apps.gpt import handler
 from api.voice_inbound import _process_speech
 from apps.gpt.make_calls.routes import process_user_speech
 from apps.gpt.make_calls.database import Call
+from apps.gpt.tool_auth import no_auth_tools
 
 
 def test_handler(default_options):
@@ -64,3 +65,24 @@ def test_processing_speech_outbound(outbound_call_key):
     assert "Play" in xml
     assert "uploadio" in xml
     
+
+def test_serper_wrapper():
+    """Test the serper wrapper."""
+    serper_tool = no_auth_tools[0]
+    
+    # Make sure we got the right one
+    assert serper_tool.name == "Google Search"
+
+    # Test basic
+    res: str = serper_tool.run("united states year of independence")
+
+    assert res
+    assert isinstance(res, str)
+    assert "1776" in res
+
+    # Test returning links
+    link_res: str = serper_tool.run("best car vacuums")
+
+    assert link_res
+    assert isinstance(link_res, str)
+    assert "https" in link_res

--- a/tests/test_app_gpt.py
+++ b/tests/test_app_gpt.py
@@ -1,6 +1,4 @@
 "Test the GPT app."
-import pytest
-
 from apps.gpt import handler
 from api.voice_inbound import _process_speech
 from apps.gpt.make_calls.routes import process_user_speech
@@ -36,12 +34,13 @@ def test_agency(default_options):
     assert "Jeeves" in res
 
 
-@pytest.mark.xfail(reason="Out of ElevenLabs credits.")
-def test_processing_speech(who_are_you_twilio_recording, default_options):
+def test_processing_speech(mocker, who_are_you_twilio_recording, default_options):
     """
     Test the background process that updates the call with a response when calling 
     Jeeves (inbound).
     """
+    mocker.patch("config.General.SANDBOX_MODE", True)
+
     response = _process_speech(
         inbound_phone=default_options["inbound_phone"],
         audio_url=who_are_you_twilio_recording
@@ -50,10 +49,9 @@ def test_processing_speech(who_are_you_twilio_recording, default_options):
     assert response
     assert (xml := response.to_xml())
     assert "Play" in xml
-    assert "uploadio" in xml
+    assert "upcdn" in xml
 
 
-@pytest.mark.xfail(reason="Out of ElevenLabs credits.")
 def test_processing_speech_outbound(outbound_call_key):
     """Test generating the next voice response when outbound calling."""
     call = Call.from_call_id(call_id=outbound_call_key)

--- a/tests/test_app_gpt.py
+++ b/tests/test_app_gpt.py
@@ -5,7 +5,9 @@ from apps.gpt import handler
 from api.voice_inbound import _process_speech
 from apps.gpt.make_calls.routes import process_user_speech
 from apps.gpt.make_calls.database import Call
-from apps.gpt.tool_auth import no_auth_tools
+from apps.gpt.tool_auth import no_auth_tools, build_tools
+
+from keys import KEYS
 
 
 def test_handler(default_options):
@@ -86,3 +88,26 @@ def test_serper_wrapper():
     assert link_res
     assert isinstance(link_res, str)
     assert "https" in link_res
+
+
+def test_building_tools(default_options):
+    """Test building the tools."""
+    # Make sure Zapier is in there
+    if KEYS.ZapierNLA:
+        tools = build_tools(
+            list(KEYS.ZapierNLA.keys())[0]
+        )
+        tool_names = [tool.name for tool in tools]
+        tool_descriptions = [tool.description for tool in tools]
+
+        assert any("Zapier" in description for description in tool_descriptions)
+    else:
+        tools = build_tools(
+            default_options["inbound_phone"]
+        )
+        tool_names = [tool.name for tool in tools]
+        tool_descriptions = [tool.description for tool in tools]
+
+    # General
+    assert tools
+    assert any("Text Message" in name for name in tool_names)

--- a/tests/test_app_gpt.py
+++ b/tests/test_app_gpt.py
@@ -3,6 +3,8 @@ import pytest
 
 from apps.gpt import handler
 from api.voice_inbound import _process_speech
+from apps.gpt.make_calls.routes import process_user_speech
+from apps.gpt.make_calls.database import Call
 
 
 def test_handler(default_options):
@@ -46,3 +48,19 @@ def test_processing_speech(who_are_you_twilio_recording, default_options):
     assert (xml := response.to_xml())
     assert "Play" in xml
     assert "uploadio" in xml
+
+
+@pytest.mark.xfail(reason="Out of ElevenLabs credits.")
+def test_processing_speech_outbound(outbound_call_key):
+    """Test generating the next voice response when outbound calling."""
+    call = Call.from_call_id(call_id=outbound_call_key)
+    voice_response = process_user_speech(
+        call_id=call.key,
+        user_speech="Hi there, how can I help you today?"
+    )
+
+    assert voice_response
+    assert (xml := voice_response.to_xml())
+    assert "Play" in xml
+    assert "uploadio" in xml
+    

--- a/tests/test_gpt_tools.py
+++ b/tests/test_gpt_tools.py
@@ -3,6 +3,7 @@ from apps.gpt.retrieval import WebsiteAnswerer, YouTubeAnswerer
 from apps.gpt.news import manual_headline_news
 from apps.gpt.tool_auth import no_auth_tools
 from apps.gpt.send_texts import create_text_message_tool
+from apps.gpt.movies import MoviesTool
 
 
 def test_website_answerer():
@@ -65,3 +66,10 @@ def test_text_tool(mocker, default_options):
     assert res
     assert isinstance(res, str)
     assert "fail" not in res.lower()
+
+
+def test_movie_tool():
+    """Currently the movie tool is not given to the agent."""
+    tool = MoviesTool()
+
+    assert "Tom Cruise" in tool.run("top gun")

--- a/tests/test_gpt_tools.py
+++ b/tests/test_gpt_tools.py
@@ -2,6 +2,7 @@
 from apps.gpt.retrieval import WebsiteAnswerer, YouTubeAnswerer
 from apps.gpt.news import manual_headline_news
 from apps.gpt.tool_auth import no_auth_tools
+from apps.gpt.send_texts import create_text_message_tool
 
 
 def test_website_answerer():
@@ -49,3 +50,17 @@ def test_wolfram_alpha():
 
     assert res
     assert "27" in res
+
+
+def test_text_tool(mocker, default_options):
+    mocker.patch("config.General.SANDBOX_MODE", True)
+
+    TextToolClass = create_text_message_tool(default_options["inbound_phone"])
+    tool = TextToolClass()
+
+    res = tool.run(
+        """{"recipient": "12223334455", "content": "Hello world!"}"""
+    )
+
+    assert res
+    assert "True" in res

--- a/tests/test_gpt_tools.py
+++ b/tests/test_gpt_tools.py
@@ -1,0 +1,51 @@
+"""Test agent tools."""
+from apps.gpt.retrieval import WebsiteAnswerer, YouTubeAnswerer
+from apps.gpt.news import manual_headline_news
+from apps.gpt.tool_auth import no_auth_tools
+
+
+def test_website_answerer():
+    answer = WebsiteAnswerer.answer_json_string(
+        """{"source": "https://example.com/", "query": "What is the domain for?"}"""
+    )
+
+    assert answer
+    assert "Unfortunately cannot answer" in answer
+
+
+def test_youtube_answerer():
+    video_link = "https://www.youtube.com/watch?v=fLeJJPxua3E"
+    question = "What is the difference between Oprah and someone who's broke?"
+
+    answer = YouTubeAnswerer.answer_json_string(
+        f"""{{"source": "{video_link}", "query": "{question}"}}"""
+    )
+
+    assert answer
+    assert "Unfortunately cannot answer" in answer 
+
+
+def test_headlines():
+    headlines = manual_headline_news("business")
+
+    assert headlines
+    assert not "Error getting headline news" in headlines
+
+
+def test_wolfram_alpha():
+    # Find the Wolfram tool
+    query_res = [
+        tool for tool in no_auth_tools if "Wolfram" in tool.name
+    ]
+
+    if not query_res:
+        raise ValueError("Wolfram Alpha tool not found.")
+
+    if len(query_res) > 1:
+        raise ValueError("Multiple Wolfram Alpha tools found.")
+    
+    wolfram_tool = query_res[0]
+    res = wolfram_tool.run("3^3")
+
+    assert res
+    assert "27" in res

--- a/tests/test_gpt_tools.py
+++ b/tests/test_gpt_tools.py
@@ -11,7 +11,7 @@ def test_website_answerer():
     )
 
     assert answer
-    assert "Unfortunately cannot answer" in answer
+    assert "Unfortunately cannot answer" not in answer
 
 
 def test_youtube_answerer():
@@ -23,14 +23,14 @@ def test_youtube_answerer():
     )
 
     assert answer
-    assert "Unfortunately cannot answer" in answer 
+    assert "Unfortunately cannot answer" not in answer 
 
 
 def test_headlines():
     headlines = manual_headline_news("business")
 
     assert headlines
-    assert not "Error getting headline news" in headlines
+    assert "Error getting headline news" not in headlines
 
 
 def test_wolfram_alpha():
@@ -63,4 +63,5 @@ def test_text_tool(mocker, default_options):
     )
 
     assert res
-    assert "True" in res
+    assert isinstance(res, str)
+    assert "fail" not in res.lower()

--- a/tests/test_voice_tools.py
+++ b/tests/test_voice_tools.py
@@ -1,0 +1,34 @@
+"""Test voice tools."""
+import pytest
+
+import string
+import random
+
+import voice_tools as vt
+
+
+@pytest.mark.xfail(reason="Out of ElevenLabs credits.")
+def test_speak():
+    """Test ElevenLabs Jeeves speaking, both generation and caching."""
+    random_words = ' '.join(
+        ''.join(
+            random.choice(string.ascii_lowercase) for _ in range(5)
+        ) for _ in range(3)
+    )
+
+    # Test speaking with generation
+    link = vt.speak.speak_jeeves(random_words)
+    assert "upcdn" in link  # upload.io link, starts with upcdn.io/
+
+    # Test caching
+    new_link = vt.speak.speak_jeeves(random_words)
+    assert link == new_link  # same link, cached
+
+
+def test_transcribe(who_are_you_twilio_recording):
+    """Test transcribing a Twilio recording."""
+    speech = vt.transcribe.transcribe_twilio_recording(
+        recording_url=who_are_you_twilio_recording
+    )
+
+    assert "who are you" in speech.lower()

--- a/tests/test_voice_tools.py
+++ b/tests/test_voice_tools.py
@@ -1,13 +1,10 @@
 """Test voice tools."""
-import pytest
-
 import string
 import random
 
 import voice_tools as vt
 
 
-@pytest.mark.xfail(reason="Out of ElevenLabs credits.")
 def test_speak():
     """Test ElevenLabs Jeeves speaking, both generation and caching."""
     random_words = ' '.join(


### PR DESCRIPTION
Start writing tests that make sense and aren't over the top (requiring super low-level mocking, etc.) to test the important logic in GPT agency, outbound calls, and inbound calls.

Mocking requests from Twilio and testing the routers would be a huge pain. Instead, because the logic is quite nicely separated (processing URLs and speech happens in separated functions that return VoiceResponse instead of updating calls alone) we can use a fake call record and a stored Twilio recording to test those processing functions alone.

The logic that isn't tested should be extremely simple and easy to follow, as is true in the case of the routers. Outbound routers, both endpoints, are very short and sweet, outsourcing important logic to standalone functions that are tested. This is fine.