### PR TITLE
Log agent behavior

### DIFF
--- a/apps/__main__.py
+++ b/apps/__main__.py
@@ -3,6 +3,7 @@ import sys
 import json
 
 from apps import PROGRAMS
+import config
 
 
 if len(sys.argv) < 2:
@@ -21,7 +22,7 @@ if len(sys.argv) > 3:
 else:
     OPTIONS = {}
 
-OPTIONS["inbound_phone"] = "00000000000"
+OPTIONS["inbound_phone"] = config.General.DEV_PHONE
 
 
 if not APP_NAME in PROGRAMS:

--- a/apps/gpt/__init__.py
+++ b/apps/gpt/__init__.py
@@ -1,9 +1,12 @@
 """GPT applet."""
 import utils
 
+import uuid
+
 from apps.gpt import agency
 from apps.gpt import tool_auth
 from apps.gpt import completions
+from apps.gpt import logs_callback
 
 
 APP_HELP = "Speak with Jeeves."
@@ -19,9 +22,11 @@ def handler(content: str, options: dict[str, str]) -> str:
         if agency_option.lower() in {"no", "false", "off"}:
             return completions.gpt_response(content)
 
-    toolkit = tool_auth.build_tools(options["inbound_phone"])
-    agent_executor = agency.create_agent_executor(toolkit)
-    response: str = agency.run_agent(agent_executor, content)
+    uid = str(uuid.uuid4())
+    callback_manager = logs_callback.create_callback_manager(uid)
+    toolkit = tool_auth.build_tools(options["inbound_phone"], callback_manager)
+    agent_executor = agency.create_agent_executor(toolkit, callback_manager)
+    response: str = agency.run_agent(agent_executor, content, uid)
 
     # Remove spaces and newlines from the start of the response
     return response.strip()

--- a/apps/gpt/agency.py
+++ b/apps/gpt/agency.py
@@ -4,8 +4,19 @@ from langchain.chat_models import ChatOpenAI
 from langchain.callbacks import get_openai_callback
 from langchain.schema import OutputParserException
 
+import logging  # log agent runs
+from logging.handlers import SysLogHandler
+
 from keys import KEYS
 from apps.gpt import prompts
+
+
+# ---- Logging ----
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+handler = SysLogHandler(address=(KEYS.Papertrail.host, KEYS.Papertrail.port))
+logger.addHandler(handler)
 
 
 # ---- Build the agent ----
@@ -67,8 +78,10 @@ def run_agent(agent_executor: AgentExecutor, query: str) -> str:
     """Run the agent."""
     with get_openai_callback() as cb:
         res = agent_executor.run(query)
-        print(f"Total Tokens: {cb.total_tokens}")
-        print(f"Prompt Tokens: {cb.prompt_tokens}")
-        print(f"Completion Tokens: {cb.completion_tokens}")
-        print(f"Total Cost (USD): ${cb.total_cost}")    
+        logger.info(
+            f"Total Tokens: {cb.total_tokens}, "
+            f"Prompt Tokens: {cb.prompt_tokens}, "
+            f"Completion Tokens: {cb.completion_tokens}, "
+            f"Total Cost (USD): ${cb.total_cost}."
+        )
         return res

--- a/apps/gpt/agency.py
+++ b/apps/gpt/agency.py
@@ -6,7 +6,7 @@ from langchain.schema import OutputParserException
 
 import logging  # log agent runs
 from logging.handlers import SysLogHandler
-from apps.gpt.logging_callback import LoggingCallbackHandler
+from apps.gpt.logging_callback import AgentLoggingCallbackHandler
 
 from keys import KEYS
 from apps.gpt import prompts
@@ -20,7 +20,7 @@ handler = SysLogHandler(address=(KEYS.Papertrail.host, KEYS.Papertrail.port))
 logger.addHandler(handler)
 
 # Log to console and to Papertrail
-logging_callback = LoggingCallbackHandler(logger=logger)
+logging_callback = AgentLoggingCallbackHandler(logger=logger)
 callback_manager = CallbackManager([logging_callback, StdOutCallbackHandler()])
 
 
@@ -85,6 +85,7 @@ def run_agent(agent_executor: AgentExecutor, query: str) -> str:
     with get_openai_callback() as cb:
         res = agent_executor.run(query)
         logger.info(
+            f"UsageInfo: "
             f"Total Tokens: {cb.total_tokens}, "
             f"Prompt Tokens: {cb.prompt_tokens}, "
             f"Completion Tokens: {cb.completion_tokens}, "

--- a/apps/gpt/logging_callback.py
+++ b/apps/gpt/logging_callback.py
@@ -7,9 +7,11 @@ from typing import Dict, Any, List, Optional, Union
 from langchain.schema import LLMResult, AgentAction, AgentFinish
 
 
-class LoggingCallbackHandler(BaseCallbackHandler):
-    """Callback Handler that prints to std out."""
-
+class AgentLoggingCallbackHandler(BaseCallbackHandler):
+    """
+    Callback Handler that logs instead of printing. 
+    Specific for agents, as it uses agent terminology in the logs.
+    """
     def __init__(self, logger: Logger) -> None:
         """Initialize callback handler."""
         self.logger = logger
@@ -39,11 +41,11 @@ class LoggingCallbackHandler(BaseCallbackHandler):
     ) -> None:
         """Print out that we are entering a chain."""
         class_name = serialized["name"]
-        self.logger.info(f"\n\n\033[1m> Entering new {class_name} chain...\033[0m")
+        self.logger.info(f"AgentStart: Entering new {class_name} chain...")
 
     def on_chain_end(self, outputs: Dict[str, Any], **kwargs: Any) -> None:
         """Print out that we finished a chain."""
-        self.logger.info("\n\033[1m> Finished chain.\033[0m")
+        self.logger.info("AgentFinish: Finished chain.")
 
     def on_chain_error(
         self, error: Union[Exception, KeyboardInterrupt], **kwargs: Any
@@ -103,4 +105,4 @@ class LoggingCallbackHandler(BaseCallbackHandler):
         self, finish: AgentFinish, color: Optional[str] = None, **kwargs: Any
     ) -> None:
         """Run on agent end."""
-        self.logger.info(finish.log)
+        self.logger.info(f"FinalAnswer: {finish.return_values['output']}")

--- a/apps/gpt/logging_callback.py
+++ b/apps/gpt/logging_callback.py
@@ -1,0 +1,106 @@
+"""Create a logging callback handler for the agent."""
+from langchain.callbacks.base import BaseCallbackHandler
+
+from logging import Logger
+
+from typing import Dict, Any, List, Optional, Union
+from langchain.schema import LLMResult, AgentAction, AgentFinish
+
+
+class LoggingCallbackHandler(BaseCallbackHandler):
+    """Callback Handler that prints to std out."""
+
+    def __init__(self, logger: Logger) -> None:
+        """Initialize callback handler."""
+        self.logger = logger
+
+    def on_llm_start(
+        self, serialized: Dict[str, Any], prompts: List[str], **kwargs: Any
+    ) -> None:
+        """Print out the prompts."""
+        pass
+
+    def on_llm_end(self, response: LLMResult, **kwargs: Any) -> None:
+        """Do nothing."""
+        pass
+
+    def on_llm_new_token(self, token: str, **kwargs: Any) -> None:
+        """Do nothing."""
+        pass
+
+    def on_llm_error(
+        self, error: Union[Exception, KeyboardInterrupt], **kwargs: Any
+    ) -> None:
+        """Do nothing."""
+        pass
+
+    def on_chain_start(
+        self, serialized: Dict[str, Any], inputs: Dict[str, Any], **kwargs: Any
+    ) -> None:
+        """Print out that we are entering a chain."""
+        class_name = serialized["name"]
+        self.logger.info(f"\n\n\033[1m> Entering new {class_name} chain...\033[0m")
+
+    def on_chain_end(self, outputs: Dict[str, Any], **kwargs: Any) -> None:
+        """Print out that we finished a chain."""
+        self.logger.info("\n\033[1m> Finished chain.\033[0m")
+
+    def on_chain_error(
+        self, error: Union[Exception, KeyboardInterrupt], **kwargs: Any
+    ) -> None:
+        """Do nothing."""
+        pass
+
+    def on_tool_start(
+        self,
+        serialized: Dict[str, Any],
+        input_str: str,
+        **kwargs: Any,
+    ) -> None:
+        """Do nothing."""
+        pass
+
+    def on_agent_action(
+        self, action: AgentAction, color: Optional[str] = None, **kwargs: Any
+    ) -> Any:
+        """Run on agent action."""
+        self.logger.info(action.log)
+
+    def on_tool_end(
+        self,
+        output: str,
+        color: Optional[str] = None,
+        observation_prefix: Optional[str] = None,
+        llm_prefix: Optional[str] = None,
+        **kwargs: Any,
+    ) -> None:
+        """If not the final action, print out observation."""
+        if observation_prefix is not None:
+            self.logger.info(observation_prefix)
+
+        self.logger.info(output)
+
+        if llm_prefix is not None:
+            self.logger.info(llm_prefix)
+
+    def on_tool_error(
+        self, error: Union[Exception, KeyboardInterrupt], **kwargs: Any
+    ) -> None:
+        """Do nothing."""
+        pass
+
+    def on_text(
+        self,
+        text: str,
+        color: Optional[str] = None,
+        end: str = "",
+        **kwargs: Any,
+    ) -> None:
+        """Run when agent ends."""
+        self.logger.info(text)
+
+    def on_agent_finish(
+        self, finish: AgentFinish, color: Optional[str] = None, **kwargs: Any
+    ) -> None:
+        """Run on agent end."""
+        self.logger.info(finish.log)

--- a/apps/gpt/logs_callback.py
+++ b/apps/gpt/logs_callback.py
@@ -1,6 +1,6 @@
 """Create a logging callback handler for the agent."""
 from langchain.callbacks.base import BaseCallbackHandler
-from langchain.callbacks import CallbackManager
+from langchain.callbacks import CallbackManager, StdOutCallbackHandler
 
 import logging
 from logging import Logger
@@ -10,6 +10,7 @@ from typing import Dict, Any, List, Optional, Union
 from langchain.schema import LLMResult, AgentAction, AgentFinish
 
 from keys import KEYS
+import config
 
 
 class AgentLoggingCallbackHandler(BaseCallbackHandler):
@@ -116,4 +117,11 @@ logger.addHandler(handler)
 
 # Log to console and to Papertrail
 logging_callback = AgentLoggingCallbackHandler(logger=logger)
-callback_manager = CallbackManager([logging_callback])
+callback_handlers = [logging_callback]
+
+# Log to console as well if configured
+if config.GPT.CONSOLE_AGENT:
+    callback_handlers.append(StdOutCallbackHandler())
+
+# Create callback manager with all handlers
+callback_manager = CallbackManager(callback_handlers)

--- a/apps/gpt/logs_callback.py
+++ b/apps/gpt/logs_callback.py
@@ -1,10 +1,15 @@
 """Create a logging callback handler for the agent."""
 from langchain.callbacks.base import BaseCallbackHandler
+from langchain.callbacks import CallbackManager
 
+import logging
 from logging import Logger
+from logging.handlers import SysLogHandler
 
 from typing import Dict, Any, List, Optional, Union
 from langchain.schema import LLMResult, AgentAction, AgentFinish
+
+from keys import KEYS
 
 
 class AgentLoggingCallbackHandler(BaseCallbackHandler):
@@ -42,6 +47,7 @@ class AgentLoggingCallbackHandler(BaseCallbackHandler):
         """Print out that we are entering a chain."""
         class_name = serialized["name"]
         self.logger.info(f"AgentStart: Entering new {class_name} chain...")
+        self.logger.info(f"UserInput: {inputs['input']}")
 
     def on_chain_end(self, outputs: Dict[str, Any], **kwargs: Any) -> None:
         """Print out that we finished a chain."""
@@ -60,13 +66,12 @@ class AgentLoggingCallbackHandler(BaseCallbackHandler):
         **kwargs: Any,
     ) -> None:
         """Do nothing."""
-        pass
 
     def on_agent_action(
         self, action: AgentAction, color: Optional[str] = None, **kwargs: Any
     ) -> Any:
         """Run on agent action."""
-        self.logger.info(action.log)
+        self.logger.info(f"AgentAction: {action.tool}: {action.tool_input}")
 
     def on_tool_end(
         self,
@@ -77,13 +82,7 @@ class AgentLoggingCallbackHandler(BaseCallbackHandler):
         **kwargs: Any,
     ) -> None:
         """If not the final action, print out observation."""
-        if observation_prefix is not None:
-            self.logger.info(observation_prefix)
-
-        self.logger.info(output)
-
-        if llm_prefix is not None:
-            self.logger.info(llm_prefix)
+        self.logger.info(f"{observation_prefix}{output}")
 
     def on_tool_error(
         self, error: Union[Exception, KeyboardInterrupt], **kwargs: Any
@@ -106,3 +105,15 @@ class AgentLoggingCallbackHandler(BaseCallbackHandler):
     ) -> None:
         """Run on agent end."""
         self.logger.info(f"FinalAnswer: {finish.return_values['output']}")
+
+
+# ---- Logging ----
+
+logger = logging.getLogger("agent")
+logger.setLevel(logging.INFO)
+handler = SysLogHandler(address=(KEYS.Papertrail.host, KEYS.Papertrail.port))
+logger.addHandler(handler)
+
+# Log to console and to Papertrail
+logging_callback = AgentLoggingCallbackHandler(logger=logger)
+callback_manager = CallbackManager([logging_callback])

--- a/apps/gpt/tool_auth.py
+++ b/apps/gpt/tool_auth.py
@@ -5,6 +5,7 @@ from langchain.utilities import GoogleSerperAPIWrapper
 from langchain.utilities.wolfram_alpha import WolframAlphaAPIWrapper
 from langchain.utilities.zapier import ZapierNLAWrapper
 from langchain.agents.agent_toolkits import ZapierToolkit
+from langchain.callbacks.base import CallbackManager
 
 from keys import KEYS
 
@@ -12,7 +13,6 @@ from apps.gpt import retrieval
 from apps.gpt import news
 from apps.gpt import send_texts
 from apps.gpt import make_calls
-from apps.gpt import logs_callback
 
 
 class GoogleSerperAPIWrapperURL(GoogleSerperAPIWrapper):
@@ -108,7 +108,7 @@ no_auth_tools: list[BaseTool] = [
 ]
 
 
-def build_tools(inbound_phone: str) -> list[Tool]:
+def build_tools(inbound_phone: str, callback_manager: CallbackManager) -> list[Tool]:
     """Build all authenticated tools given a phone number."""
     added_tools = []
 
@@ -128,6 +128,6 @@ def build_tools(inbound_phone: str) -> list[Tool]:
 
     # Add callback manager to all tools
     for tool in tools:
-        tool.callback_manager = logs_callback.callback_manager
+        tool.callback_manager = callback_manager
 
     return tools

--- a/apps/gpt/tool_auth.py
+++ b/apps/gpt/tool_auth.py
@@ -12,6 +12,7 @@ from apps.gpt import retrieval
 from apps.gpt import news
 from apps.gpt import send_texts
 from apps.gpt import make_calls
+from apps.gpt import logs_callback
 
 
 class GoogleSerperAPIWrapperURL(GoogleSerperAPIWrapper):
@@ -122,4 +123,11 @@ def build_tools(inbound_phone: str) -> list[Tool]:
     TextToolClass = send_texts.create_text_message_tool(inbound_phone)
     added_tools.append(TextToolClass())
 
-    return no_auth_tools + added_tools
+    # Add all tools together
+    tools = no_auth_tools + added_tools
+
+    # Add callback manager to all tools
+    for tool in tools:
+        tool.callback_manager = logs_callback.callback_manager
+
+    return tools

--- a/config.ini
+++ b/config.ini
@@ -1,6 +1,7 @@
 [General]
 sandbox_mode = false
 threaded_inbound = false
+dev_phone = 12223334455
 
 
 [Weather]
@@ -13,3 +14,7 @@ translation = false
 
 [Cocktails]
 result_limit = 3
+
+
+[GPT]
+console_agent = false

--- a/config.py
+++ b/config.py
@@ -55,6 +55,7 @@ def read_bool_option(option: str) -> bool:
 class General:
     SANDBOX_MODE: bool = read_bool_option(config["General"]["sandbox_mode"])
     THREADED_INBOUND: bool = read_bool_option(config["General"]["threaded_inbound"])
+    DEV_PHONE: str = config["General"]["dev_phone"]
 
 
 class Weather:
@@ -68,3 +69,7 @@ class Groceries:
 
 class Cocktails:
     RESULT_LIMIT: int = int(config["Cocktails"]["result_limit"])
+
+
+class GPT:
+    CONSOLE_AGENT: bool = read_bool_option(config["GPT"]["console_agent"])

--- a/keys/models.py
+++ b/keys/models.py
@@ -128,6 +128,18 @@ class TranscriptionModel(BaseModel):
     api_url: str
 
 
+class PapertrailModel(BaseModel):
+    """
+    A Pydantic model for Papertrail logging in the cloud.
+
+    Attributes:
+        host (str): The Papertrail host.
+        port (int): The Papertrail port.
+    """
+    host: str
+    port: int
+
+
 class Keys(BaseModel):
     """
     A Pydantic model for validating all API keys configurations.
@@ -145,6 +157,7 @@ class Keys(BaseModel):
         ElevenLabs (ElevenLabsModel): The ElevenLabs configuration model.
         UploadIO (UploadIOModel): The UploadIO configuration model.
         Transcription (TranscriptionModel): The Transcription configuration model.
+        Papertrail (PapertrailModel): The Papertrail logging configuration model.
     """
     # Required keys (tests and active applets)
     Twilio: TwilioModel
@@ -157,6 +170,7 @@ class Keys(BaseModel):
     ElevenLabs: ElevenLabsModel
     UploadIO: UploadIOModel
     Transcription: TranscriptionModel
+    Papertrail: PapertrailModel
 
     # Optional keys (Optional features and inactive applets/features)
     ZapierNLA: dict[str, str] | None

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ emoji==2.2.0  # emojis in drink formatting
 
 # GPT
 openai==0.27.4
-langchain==0.0.154
+langchain==0.0.153
 faiss-cpu==1.7.4
 tiktoken==0.3.3
 beautifulsoup4==4.12.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ emoji==2.2.0  # emojis in drink formatting
 
 # GPT
 openai==0.27.4
-langchain==0.0.150
+langchain==0.0.154
 faiss-cpu==1.7.4
 tiktoken==0.3.3
 beautifulsoup4==4.12.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -171,4 +171,5 @@ def outbound_call_key() -> str:
 @pytest.fixture(scope="session")
 def callback_manager():
     """Callback manager with testing uid."""
-    return create_callback_manager(uid="tests")
+    uid = f"tests-{dt.datetime.utcnow().utcnow()}"
+    return create_callback_manager(uid=uid)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ import usage  # fixture for temporary logs for report
 import permissions  # fixtures for temporary users
 
 from apps.gpt.make_calls.database import Call
+from apps.gpt.logs_callback import create_callback_manager
 
 
 @pytest.fixture(scope="session")
@@ -165,3 +166,9 @@ def outbound_call_key() -> str:
 
     # Remove the temporary call
     call.delete()
+
+
+@pytest.fixture(scope="session")
+def callback_manager():
+    """Callback manager with testing uid."""
+    return create_callback_manager(uid="tests")

--- a/tests/test_app_gpt.py
+++ b/tests/test_app_gpt.py
@@ -88,12 +88,13 @@ def test_serper_wrapper():
     assert "https" in link_res
 
 
-def test_building_tools(default_options):
+def test_building_tools(default_options, callback_manager):
     """Test building the tools. Zapier and text requires auth."""
     # Make sure Zapier is in there, use first provided phone 
     if KEYS.ZapierNLA:
         tools = build_tools(
-            list(KEYS.ZapierNLA.keys())[0]
+            inbound_phone=list(KEYS.ZapierNLA.keys())[0],
+            callback_manager=callback_manager
         )
         tool_names = [tool.name for tool in tools]
         tool_descriptions = [tool.description for tool in tools]
@@ -101,7 +102,8 @@ def test_building_tools(default_options):
         assert any("Zapier" in description for description in tool_descriptions)
     else:
         tools = build_tools(
-            default_options["inbound_phone"]
+            inbound_phone=default_options["inbound_phone"],
+            callback_manager=callback_manager
         )
         tool_names = [tool.name for tool in tools]
         tool_descriptions = [tool.description for tool in tools]


### PR DESCRIPTION
Instead of printing to console and watching GCR logs. Right now logging to Papertrail usage information works, but logging in the agent information will be more tricky. Will require a callback handler.