### PR TITLE
Provide Jeeves with conversation history

### DIFF
--- a/apps/gpt/chat_history/__init__.py
+++ b/apps/gpt/chat_history/__init__.py
@@ -1,0 +1,1 @@
+"""Retrieve and store chat history."""

--- a/apps/gpt/chat_history/__init__.py
+++ b/apps/gpt/chat_history/__init__.py
@@ -1,1 +1,3 @@
 """Retrieve and store chat history."""
+from apps.gpt.chat_history.database import ChatHistory
+from apps.gpt.chat_history.filter import RecencyFilterer

--- a/apps/gpt/chat_history/database.py
+++ b/apps/gpt/chat_history/database.py
@@ -49,6 +49,14 @@ class ChatHistory:
         """
         Retrieve chat history from the database.
         """
+        # Validate the inbound phone number
+        if inbound_phone.startswith("+"):
+            inbound_phone = inbound_phone[1:]
+        
+        assert inbound_phone.isnumeric(), "Inbound phone number must be numeric."
+        assert len(inbound_phone) == 11, \
+            "Inbound phone number must be 11 digits, E.164 format."
+
         user_messages = chats_base.fetch({"inbound_phone": inbound_phone}).items
 
         # Parse the messages into a list of Message objects

--- a/apps/gpt/chat_history/database.py
+++ b/apps/gpt/chat_history/database.py
@@ -53,7 +53,6 @@ class ChatHistory:
     def add_message(self, message: Message) -> str:
         """
         Add a message to the database. 
-        
         Returns a dictionary of the full database entry.
         """
         return chats_base.put(message.to_dict())

--- a/apps/gpt/chat_history/database.py
+++ b/apps/gpt/chat_history/database.py
@@ -35,14 +35,17 @@ class ChatHistory:
         Format messages into a string. Returns a string. Providing a Filterer 
         is optional, but will filter the messages first before formatting.
         """
-        formatted: str = ""
         messages = self.messages
 
         if filterer is not None:
             messages = self.filter_messages(filterer)
 
-        for message in messages:
-            formatted += f"Me: {message.user_input}\nJeeves: {message.agent_response}\n"
+        message_strings: list[str] = [
+            f"Me: {message.user_input}\nJeeves: {message.agent_response}"
+            for message in messages
+        ]
+
+        return "\n".join(message_strings)
 
     @classmethod
     def from_inbound_phone(cls, inbound_phone: str) -> "ChatHistory":

--- a/apps/gpt/chat_history/database.py
+++ b/apps/gpt/chat_history/database.py
@@ -5,6 +5,7 @@ import datetime as dt
 
 from keys import KEYS
 from apps.gpt.chat_history.models import Message
+from apps.gpt.chat_history.filter import BaseFilterer
 
 
 # Initialize the chats Deta Base
@@ -23,16 +24,15 @@ class ChatHistory:
         """Initialize the chat history."""
         self.messages = messages
 
-    def filter_messages(self, start: dt.datetime, end: dt.datetime) -> list[Message]:
+    def filter_messages(self, filterer: BaseFilterer) -> list[Message]:
         """Filter messages by datetime."""
-        return [
-            message for message in self.messages 
-                if start <= message.datetime <= end
-        ]
+        return filterer.filter_messages(self.messages)
 
     @classmethod
     def from_inbound_phone(cls, inbound_phone: str) -> "ChatHistory":
-        """Retrieve chat history from the database."""
+        """
+        Retrieve chat history from the database.
+        """
         user_messages = chats_base.fetch({"inbound_phone": inbound_phone}).items
 
         # Parse the messages into a list of Message objects
@@ -47,3 +47,11 @@ class ChatHistory:
         ]
 
         return cls(messages=messages)
+
+    def add_message(self, message: Message) -> str:
+        """
+        Add a message to the database. 
+        
+        Returns a dictionary of the full database entry.
+        """
+        return chats_base.put(message.to_dict())

--- a/apps/gpt/chat_history/database.py
+++ b/apps/gpt/chat_history/database.py
@@ -1,0 +1,49 @@
+"""Interact with a chats Deta Base to facilitate chat history."""
+import deta
+
+import datetime as dt
+
+from keys import KEYS
+from apps.gpt.chat_history.models import Message
+
+
+# Initialize the chats Deta Base
+chats_base = deta.Deta(KEYS.Deta.project_key).Base("chats")
+
+
+class ChatHistory:
+    """
+    A chat history object to interact with the database.
+    
+    `dt.datetime` is stored in the database in string format, isoformat.
+    Serialize datetimes using `dt.datetime.isoformat()` into the database,
+    and deserialize using `dt.datetime.fromisoformat()`.
+    """
+    def __init__(self, messages: list[Message]) -> None:
+        """Initialize the chat history."""
+        self.messages = messages
+
+    def filter_messages(self, start: dt.datetime, end: dt.datetime) -> list[Message]:
+        """Filter messages by datetime."""
+        return [
+            message for message in self.messages 
+                if start <= message.datetime <= end
+        ]
+
+    @classmethod
+    def from_inbound_phone(cls, inbound_phone: str) -> "ChatHistory":
+        """Retrieve chat history from the database."""
+        user_messages = chats_base.fetch({"inbound_phone": inbound_phone}).items
+
+        # Parse the messages into a list of Message objects
+        messages = [
+            Message(
+                datetime=dt.datetime.fromisoformat(message["datetime"]),
+                user_input=message["user_input"],
+                agent_response=message["agent_response"],
+                inbound_phone=message["inbound_phone"]
+            )
+            for message in user_messages
+        ]
+
+        return cls(messages=messages)

--- a/apps/gpt/chat_history/database.py
+++ b/apps/gpt/chat_history/database.py
@@ -25,7 +25,9 @@ class ChatHistory:
         self.messages = messages
 
     def filter_messages(self, filterer: BaseFilterer) -> list[Message]:
-        """Filter messages by datetime."""
+        """
+        Filter messages by datetime. Returns a list of Messages.
+        """
         return filterer.filter_messages(self.messages)
 
     @classmethod

--- a/apps/gpt/chat_history/database.py
+++ b/apps/gpt/chat_history/database.py
@@ -30,6 +30,20 @@ class ChatHistory:
         """
         return filterer.filter_messages(self.messages)
 
+    def format_messages(self, filterer: BaseFilterer | None = None) -> str:
+        """
+        Format messages into a string. Returns a string. Providing a Filterer 
+        is optional, but will filter the messages first before formatting.
+        """
+        formatted: str = ""
+        messages = self.messages
+
+        if filterer is not None:
+            messages = self.filter_messages(filterer)
+
+        for message in messages:
+            formatted += f"Me: {message.user_input}\nJeeves: {message.agent_response}\n"
+
     @classmethod
     def from_inbound_phone(cls, inbound_phone: str) -> "ChatHistory":
         """

--- a/apps/gpt/chat_history/filter.py
+++ b/apps/gpt/chat_history/filter.py
@@ -1,0 +1,63 @@
+"""Filter messages."""
+from abc import ABC, abstractmethod
+
+import datetime as dt
+
+from apps.gpt.chat_history.models import Message
+
+
+class BaseFilterer(ABC):
+    """Base class for filterers."""
+
+    @abstractmethod
+    def filter_messages(self, messages: list[Message]) -> list[Message]:
+        """
+        Filter the messages. Input schema is the same as output schema. Order matters.
+        """
+        raise NotImplementedError
+
+
+class DatetimeFilterer(BaseFilterer):
+    """
+    Filter messages by datetime.
+    
+    Takes a start and end datetime, and returns all messages that fall within
+    that range.
+    """
+
+    def __init__(self, start: dt.datetime, end: dt.datetime) -> None:
+        """Initialize the filterer."""
+        # Valid parameters check
+        assert isinstance(start, dt.datetime), "Start datetime must be a datetime."
+        assert isinstance(end, dt.datetime), "End datetime must be a datetime."
+        assert start <= end, "Start datetime must be before end datetime."
+
+        self.start = start
+        self.end = end
+
+    def filter_messages(self, messages: list[Message]) -> list[Message]:
+        """Filter messages by datetime."""
+        return [
+            message
+            for message in messages
+            if self.start <= message.datetime <= self.end
+        ]
+
+
+class RecencyFilterer(BaseFilterer):
+    """
+    Filter messages by recency. 
+
+    Takes `n_messages` and returns the `n_messages` most recent messages.
+    """
+    def __init__(self, n_messages: int) -> None:
+        """Initialize the filterer."""
+        self.n_messages = int(n_messages)
+
+    def filter_messages(self, messages: list[Message]) -> list[Message]:
+        """Filter messages by recency."""
+        # Sort the messages by datetime, most recent first
+        messages = sorted(messages, key=lambda message: message.datetime, reverse=True)
+
+        # Return the first n_messages
+        return messages[:self.n_messages]

--- a/apps/gpt/chat_history/filter.py
+++ b/apps/gpt/chat_history/filter.py
@@ -59,5 +59,9 @@ class RecencyFilterer(BaseFilterer):
         # Sort the messages by datetime, most recent first
         messages = sorted(messages, key=lambda message: message.datetime, reverse=True)
 
+        # If there are fewer messages than n_messages, return all messages
+        if len(messages) < self.n_messages:
+            return messages
+
         # Return the first n_messages
         return messages[:self.n_messages]

--- a/apps/gpt/chat_history/models.py
+++ b/apps/gpt/chat_history/models.py
@@ -10,9 +10,11 @@ class Message(BaseModel):
     
     Attributes:
         datetime: The datetime of the message. 
+        inbound_phone: The inbound phone number.
         user_input: The user input.
         agent_response: The agent response.
     """
     datetime: dt.datetime
+    inbound_phone: str
     user_input: str
     agent_response: str

--- a/apps/gpt/chat_history/models.py
+++ b/apps/gpt/chat_history/models.py
@@ -18,3 +18,12 @@ class Message(BaseModel):
     inbound_phone: str
     user_input: str
     agent_response: str
+
+    def to_dict(self) -> dict:
+        """Return the message as a dictionary."""
+        return {
+            "datetime": self.datetime.isoformat(),
+            "inbound_phone": self.inbound_phone,
+            "user_input": self.user_input,
+            "agent_response": self.agent_response
+        }

--- a/apps/gpt/chat_history/models.py
+++ b/apps/gpt/chat_history/models.py
@@ -1,0 +1,18 @@
+"""Models for chat history."""
+from pydantic import BaseModel
+
+import datetime as dt
+
+
+class Message(BaseModel):
+    """
+    A Message is both the user input and the agent response.
+    
+    Attributes:
+        datetime: The datetime of the message. 
+        user_input: The user input.
+        agent_response: The agent response.
+    """
+    datetime: dt.datetime
+    user_input: str
+    agent_response: str

--- a/apps/gpt/prompts/__init__.py
+++ b/apps/gpt/prompts/__init__.py
@@ -18,8 +18,6 @@ import os
 import datetime as dt
 import pytz
 
-from apps.gpt.chat_history.models import Message
-
 
 # ---- Model for prompting ---- 
 
@@ -126,10 +124,10 @@ def _build_prompt(name: str, **kwargs) -> Prompt:
     )
 
 
-def build_prompts(messages: list[Message]) -> AgentPrompts:
+def build_prompts(chat_history: str) -> AgentPrompts:
     """Build the prompts inserting any variables necessary."""
     return AgentPrompts(
         prefix=_build_prompt("prefix").build_prompt(),
         format_instructions=_build_prompt("format_instructions").build_prompt(),
-        suffix=_build_prompt("suffix").build_prompt()
+        suffix=_build_prompt("suffix").build_prompt(chat_history=chat_history)
     )

--- a/apps/gpt/prompts/__init__.py
+++ b/apps/gpt/prompts/__init__.py
@@ -14,10 +14,11 @@ from pydantic import BaseModel
 
 from typing import Callable
 import string
-
 import os
 import datetime as dt
 import pytz
+
+from apps.gpt.chat_history.models import Message
 
 
 # ---- Model for prompting ---- 
@@ -66,12 +67,16 @@ class Prompt:
         self.template = template
         self.input_variables = input_variables
 
-    def build_prompt(self) -> str:
+    def build_prompt(self, **kwargs) -> str:
         """Build the prompt using self.input_variables."""
         if self.input_variables is None:
             return self.template
 
-        return PartialFormatter().format(self.template, **self.input_variables)
+        # Update the input variables with the given kwargs
+        input_variables = self.input_variables.copy()
+        input_variables.update(kwargs)
+
+        return PartialFormatter().format(self.template, **input_variables)
 
 
 # ---- Build the prompts ----
@@ -84,6 +89,9 @@ current_datetime = lambda: dt.datetime.now(pytz.timezone("US/Eastern")).strftime
     "%-I:%M%p on %A, %B %d, %Y"
 )
 
+# The reason these are stored in this Callable fashion is so the values are only
+# evaluated when the prompt is built. This is because the values may change over time,
+# ex. the date and time.
 PROMPT_INPUTS: dict[str, dict[str, Callable]] = {
     "prefix": {
         "current_datetime": current_datetime
@@ -93,8 +101,8 @@ PROMPT_INPUTS: dict[str, dict[str, Callable]] = {
 }
 
 
-def _build_prompt(name: str) -> Prompt:
-    """Build the prompt with the given name."""
+def _build_prompt(name: str, **kwargs) -> Prompt:
+    """Build the prompt with the given name. Pass in any inputs as kwargs."""
     if name not in PROMPT_INPUTS:
         raise ValueError(f"Prompt name {name} not found.")
 
@@ -104,15 +112,21 @@ def _build_prompt(name: str) -> Prompt:
     with open(prompt_path(name), "r", encoding="utf-8") as f:
         template = f.read()
 
-    input_dict: dict[str, Callable] = PROMPT_INPUTS[name]
+    # Input dictionary will evaluate the functions in PROMPT_INPUTS[name]
+    input_dict: dict[str, str] = {
+        var: PROMPT_INPUTS[name][var]() for var in PROMPT_INPUTS[name]
+    }
+
+    # Add any kwargs to the input dictionary
+    input_dict.update(kwargs)
 
     return Prompt(
         template=template,
-        input_variables={var: input_dict[var]() for var in input_dict}
+        input_variables=input_dict
     )
 
 
-def build_prompts() -> AgentPrompts:
+def build_prompts(messages: list[Message]) -> AgentPrompts:
     """Build the prompts inserting any variables necessary."""
     return AgentPrompts(
         prefix=_build_prompt("prefix").build_prompt(),

--- a/apps/gpt/prompts/suffix.txt
+++ b/apps/gpt/prompts/suffix.txt
@@ -1,3 +1,7 @@
+For reference, here is our recent message history.
+
+{chat_history}
+
 Begin! 
 
 Input: {input}

--- a/tests/test_app_gpt.py
+++ b/tests/test_app_gpt.py
@@ -26,6 +26,9 @@ def test_agency(mocker, default_options, callback_uid):
     """Test the GPT applet handler."""
     mocker.patch("apps.gpt.__init__.uuid.uuid4", return_value=callback_uid)
 
+    # Don't add chat logs
+    mocker.patch("apps.gpt.chat_history.database.ChatHistory.add_message", return_value=None)
+
     res = handler(
         content="Who are you?",
         options=default_options
@@ -43,6 +46,9 @@ def test_processing_speech(mocker, who_are_you_twilio_recording, default_options
     """
     mocker.patch("api.voice_inbound.texts.CONFIG.General.sandbox_mode", True)
 
+    # Don't add chat logs
+    mocker.patch("apps.gpt.chat_history.database.ChatHistory.add_message", return_value=None)
+
     response = _process_speech(
         inbound_phone=default_options["inbound_phone"],
         audio_url=who_are_you_twilio_recording,
@@ -55,8 +61,11 @@ def test_processing_speech(mocker, who_are_you_twilio_recording, default_options
     assert "upcdn" in xml
 
 
-def test_processing_speech_outbound(outbound_call_key):
+def test_processing_speech_outbound(outbound_call_key, mocker):
     """Test generating the next voice response when outbound calling."""
+    # Don't add chat logs
+    mocker.patch("apps.gpt.chat_history.database.ChatHistory.add_message", return_value=None)
+
     call = Call.from_call_id(call_id=outbound_call_key)
     voice_response = process_user_speech(
         call_id=call.key,


### PR DESCRIPTION
## Changes:

1. Added imports for `datetime` in `apps/gpt/__init__.py` and created `ChatHistory` and `Message` objects.
2. Implemented chat history building in `generate_agent_response` function in `apps/gpt/__init__.py`.
3. Added functionality to save messages to the chat history database.
4. Modified `create_agent_executor` function in `apps/gpt/agency.py` to include `chat_history` as an argument and updated `agent_prompts` accordingly.
5. Created new files in `apps/gpt/chat_history` for retrieving and storing chat history, filtering messages, and defining chat history models.
6. Updated `apps/gpt/prompts/__init__.py` and `apps/gpt/prompts/suffix.txt` to include chat history in the suffix prompt.

## High-level overview:

This pull request introduces chat history functionality to the GPT-4 app. This allows for better context and user experience by allowing the AI to recall and reference previous messages in the conversation.

The changes include the creation of a `ChatHistory` object, which interacts with a chat database, and a `Message` object, which represents a single user input and agent response pair. The `generate_agent_response` function in `apps/gpt/__init__.py` now builds the chat history, creates the `ChatHistory` object, and saves messages to the chat database.

In `apps/gpt/agency.py`, the `create_agent_executor` function has been modified to accept the `chat_history` object as an argument. This is then used to build the `agent_prompts`, allowing the AI to reference the chat history.

New files have been added to `apps/gpt/chat_history` to handle retrieving and storing chat history, filtering messages, and defining chat history models. The chat history is now included in the suffix prompt in `apps/gpt/prompts/__init__.py` and `apps/gpt/prompts/suffix.txt`.