### PR TITLE
Run tests on chat history filterers

### DIFF
--- a/tests/test_message_filterers.py
+++ b/tests/test_message_filterers.py
@@ -1,7 +1,62 @@
 """Test chat history message filterers."""
+import pytest
+
+import datetime as dt
+import pytz
+
+from config import CONFIG
 from apps.gpt.chat_history.filter import RecencyFilterer
 from apps.gpt.chat_history.models import Message
 
 
-def test_recency_filterer():
+tz = pytz.timezone(CONFIG.General.default_timezone)
+
+@pytest.fixture(scope="module")
+def temporary_messages(default_inbound) -> list[Message]:
+    """Return a list of temporary messages."""
+    return [
+        Message(
+            datetime=dt.datetime(2021, 1, 1, 0, 0, 0, tzinfo=tz),
+            inbound_phone=default_inbound["phone_number"],
+            user_input="Hello",
+            agent_response="Hi.",
+        ),
+        Message(
+            datetime=dt.datetime(2021, 1, 2, 0, 0, 0, tzinfo=tz),
+            inbound_phone=default_inbound["phone_number"],
+            user_input="How are you?",
+            agent_response="I'm good.",
+        ),
+        Message(
+            datetime=dt.datetime(2021, 1, 3, 0, 0, 0, tzinfo=tz),
+            inbound_phone=default_inbound["phone_number"],
+            user_input="What's your name?",
+            agent_response="My name is Bob.",
+        ),
+        Message(
+            datetime=dt.datetime(2021, 1, 4, 0, 0, 0, tzinfo=tz),
+            inbound_phone=default_inbound["phone_number"],
+            user_input="What's your favorite color?",
+            agent_response="My favorite color is blue.",
+        ),
+        Message(
+            datetime=dt.datetime(2021, 1, 5, 0, 0, 0, tzinfo=tz),
+            inbound_phone=default_inbound["phone_number"],
+            user_input="What's your favorite food?",
+            agent_response="My favorite food is pizza.",
+        ),
+        Message(
+            datetime=dt.datetime(2021, 1, 6, 0, 0, 0, tzinfo=tz),
+            inbound_phone=default_inbound["phone_number"],
+            user_input="What's your favorite animal?",
+            agent_response="My favorite animal is a dog.",
+        )
+    ]
+
+
+def test_recency_filterer(temporary_messages):
     filterer = RecencyFilterer(n_messages=5)
+    filtered_messages = filterer.filter_messages(temporary_messages)
+
+    assert len(filtered_messages) == 5
+    assert filtered_messages[0].user_input == "What's your favorite animal?"

--- a/tests/test_message_filterers.py
+++ b/tests/test_message_filterers.py
@@ -1,0 +1,7 @@
+"""Test chat history message filterers."""
+from apps.gpt.chat_history.filter import RecencyFilterer
+from apps.gpt.chat_history.models import Message
+
+
+def test_recency_filterer():
+    filterer = RecencyFilterer(n_messages=5)

--- a/tests/test_message_filterers.py
+++ b/tests/test_message_filterers.py
@@ -5,7 +5,7 @@ import datetime as dt
 import pytz
 
 from config import CONFIG
-from apps.gpt.chat_history.filter import RecencyFilterer
+from apps.gpt.chat_history.filter import RecencyFilterer, DatetimeFilterer
 from apps.gpt.chat_history.models import Message
 
 
@@ -54,6 +54,8 @@ def temporary_messages(default_inbound) -> list[Message]:
     ]
 
 
+# ---- Recency ----
+
 def test_recency_filterer(temporary_messages):
     """
     Test the recency filterer. Make sure it returns the correct number of messages,
@@ -76,3 +78,43 @@ def test_recency_filterer(temporary_messages):
     # Make sure the messages are in chronological order
     assert filtered_messages == sorted(filtered_messages, key=lambda m: m.datetime)
     
+
+# ---- Datetime ----
+
+def test_datetime_filterer(temporary_messages):
+    """
+    Test the datetime filterer. Make sure it returns the correct messages that fall
+    within the specified datetime range.
+    """
+    start_datetime = dt.datetime(2021, 1, 2, 0, 0, 0, tzinfo=tz)
+    end_datetime = dt.datetime(2021, 1, 5, 0, 0, 0, tzinfo=tz)
+    filterer = DatetimeFilterer(start=start_datetime, end=end_datetime)
+    filtered_messages = filterer.filter_messages(temporary_messages)
+
+    # Make sure 4 messages are within the specified range
+    assert len(filtered_messages) == 4
+
+    # Make sure the messages are in the specified range
+    for message in filtered_messages:
+        assert start_datetime <= message.datetime <= end_datetime
+
+    # Make sure the bookend messages are correct (first and last in the range)
+    assert filtered_messages[0].user_input == "How are you?"
+    assert filtered_messages[-1].user_input == "What's your favorite food?"
+
+    # Messages outside the specified range shouldn't be in the filtered messages
+    assert all(m.user_input != "Hello" for m in filtered_messages)
+    assert all(m.user_input != "What's your favorite animal?" for m in filtered_messages)
+
+
+def test_datetime_filterer_empty_result(temporary_messages):
+    """
+    Test the datetime filterer when no messages fall within the specified datetime range.
+    """
+    start_datetime = dt.datetime(2021, 1, 10, 0, 0, 0, tzinfo=tz)
+    end_datetime = dt.datetime(2021, 1, 12, 0, 0, 0, tzinfo=tz)
+    filterer = DatetimeFilterer(start=start_datetime, end=end_datetime)
+    filtered_messages = filterer.filter_messages(temporary_messages)
+
+    # Make sure no messages are within the specified range
+    assert len(filtered_messages) == 0

--- a/tests/test_message_filterers.py
+++ b/tests/test_message_filterers.py
@@ -59,4 +59,4 @@ def test_recency_filterer(temporary_messages):
     filtered_messages = filterer.filter_messages(temporary_messages)
 
     assert len(filtered_messages) == 5
-    assert filtered_messages[0].user_input == "What's your favorite animal?"
+    assert filtered_messages[-1].user_input == "What's your favorite animal?"

--- a/tests/test_message_filterers.py
+++ b/tests/test_message_filterers.py
@@ -55,8 +55,24 @@ def temporary_messages(default_inbound) -> list[Message]:
 
 
 def test_recency_filterer(temporary_messages):
+    """
+    Test the recency filterer. Make sure it returns the correct number of messages,
+    and that the messages are sorted by datetime. Make sure the bookend messages are
+    correct. Make sure the first message isn't in there.
+    """
     filterer = RecencyFilterer(n_messages=5)
     filtered_messages = filterer.filter_messages(temporary_messages)
 
+    # Make sure 5 sorted messages
     assert len(filtered_messages) == 5
+    
+    # Make sure the bookend messages are correct (last and 2nd for 5 messages)
     assert filtered_messages[-1].user_input == "What's your favorite animal?"
+    assert filtered_messages[0].user_input == "How are you?"
+
+    # The first message shouldn't be in there (6 messages)
+    assert all(m.user_input != "Hello" for m in filtered_messages)
+
+    # Make sure the messages are in chronological order
+    assert filtered_messages == sorted(filtered_messages, key=lambda m: m.datetime)
+    


### PR DESCRIPTION
This PR introduces a new test file, `test_message_filterers.py`, to test the functionality of chat history message filterers. These tests cover the `RecencyFilterer` and `DatetimeFilterer` classes, ensuring they return the expected messages based on the filtering criteria. 

In fact, writing these tests exposed a massive oversight when creating the `RecencyFilterer`, being that messages were sorted backwards (with most recent first) resulting in a backwards ordering of chat history. 

Closes #64.

## Changes

- Created `test_message_filterers.py` file.
- Added `temporary_messages` fixture to generate a list of temporary messages for testing.
- Implemented tests for `RecencyFilterer`:
  - Test `test_recency_filterer` checks that the correct number of messages are returned, messages are sorted by datetime, the bookend messages are correct, and the first message isn't included.
- Implemented tests for `DatetimeFilterer`:
  - Test `test_datetime_filterer` checks that the correct messages within the specified datetime range are returned, the bookend messages are correct, and messages outside the range aren't included.
  - Test `test_datetime_filterer_empty_result` checks the case where no messages fall within the specified datetime range and ensures an empty list is returned.

## Purpose

These tests aim to validate the functionality of the message filterers, ensuring that they return the correct messages based on the given filtering criteria. This will help maintain the reliability and accuracy of the chat history filtering feature.
