### PR TITLE
Zapier tokens as a provider

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -7,7 +7,7 @@ endpoint.
 from fastapi import FastAPI
 
 # Routers
-from api import text_inbound, voice_inbound, telegram_inbound, voice_outbound
+from api import text_inbound, voice_inbound, telegram_inbound, voice_outbound, authentication
 
 
 app = FastAPI(
@@ -30,3 +30,4 @@ app.include_router(voice_inbound.router, prefix="/voice", tags=["Voice Inbound"]
 app.include_router(
     voice_outbound.router, prefix="/voice/outbound", tags=["Voice Outbound Calls"]
 )
+app.include_router(authentication.router, prefix="/auth", tags=["Authentication"])

--- a/api/authentication.py
+++ b/api/authentication.py
@@ -1,0 +1,21 @@
+"""Routes for authenticating, ex. Zapier."""
+from fastapi import APIRouter
+import requests
+
+from jeeves.keys import KEYS
+
+
+router = APIRouter()
+
+
+@router.get("/zapier-handler/{user_key}")
+async def handle_zapier(user_key: str, code: str):
+    """
+    Handle a Zapier authentication code.
+
+    Args:
+        user_key (str): The user key - Deta key for their user entry.
+        code (str): The authentication code.
+    """
+    print(code)
+    return {"code": code}

--- a/api/authentication.py
+++ b/api/authentication.py
@@ -1,6 +1,7 @@
 """Routes for authenticating, ex. Zapier."""
-from fastapi import APIRouter
+from fastapi import APIRouter, Response
 import requests
+from deta import Deta
 
 from jeeves.keys import KEYS
 
@@ -8,14 +9,48 @@ from jeeves.keys import KEYS
 router = APIRouter()
 
 
+permissions_db = Deta(KEYS.Deta.project_key).Base("permissions")
+
+
 @router.get("/zapier-handler/{user_key}")
 async def handle_zapier(user_key: str, code: str):
     """
-    Handle a Zapier authentication code.
+    Handle a Zapier authentication code. Takes the code and update's the user's
+    access token in the permissions database.
 
     Args:
         user_key (str): The user key - Deta key for their user entry.
         code (str): The authentication code.
     """
-    print(code)
-    return {"code": code}
+    # Find the user in the database
+    user = permissions_db.get(user_key)
+
+    if not user:
+        return Response("User not found.", status_code=404)
+
+    # Generate the access token and refresh token
+    url = "https://nla.zapier.com/oauth/token"
+    res = requests.post(
+        url,
+        data={
+            "client_id": KEYS.Zapier.client_id,
+            "client_secret": KEYS.Zapier.client_secret,
+            "code": code,
+            "grant_type": "authorization_code"
+        },
+        headers={
+            "Content-Type": "application/x-www-form-urlencoded"
+        }
+    )
+
+    if res.status_code != 200:
+        return Response("Error generating access token.", status_code=500)
+
+    # Update the user's access token
+    user["ZapierAccessToken"] = res.json()["access_token"]
+    user["ZapierRefreshToken"] = res.json()["refresh_token"]
+
+    # Save the user
+    permissions_db.put(user)
+
+    return Response("Success!", status_code=200)

--- a/jeeves/agency/tool_auth.py
+++ b/jeeves/agency/tool_auth.py
@@ -117,7 +117,7 @@ def build_tools(
     added_tools: list[BaseTool] = []
 
     # Zapier
-    if user.zapier_key:
+    if user.zapier_access_token:
         zapier_wrapper = ZapierNLAWrapper(
             zapier_nla_oauth_access_token=user.zapier_access_token
         )

--- a/jeeves/agency/tool_auth.py
+++ b/jeeves/agency/tool_auth.py
@@ -118,7 +118,9 @@ def build_tools(
 
     # Zapier
     if user.zapier_key:
-        zapier_wrapper = ZapierNLAWrapper(zapier_nla_api_key=user.zapier_key)
+        zapier_wrapper = ZapierNLAWrapper(
+            zapier_nla_oauth_access_token=user.zapier_access_token
+        )
         zapier_toolkit = ZapierToolkit.from_zapier_nla_wrapper(zapier_wrapper)
         added_tools.extend(zapier_toolkit.get_tools())
 

--- a/jeeves/keys/models.py
+++ b/jeeves/keys/models.py
@@ -152,6 +152,20 @@ class TelegramModel(BaseModel):
     api_secret_token: str
 
 
+class ZapierModel(BaseModel):
+    """
+    Model for Zapier providership.
+    
+    Attributes:
+        provider_id (str): The provider ID.
+        client_id (str): The client ID.
+        client_secret (str): The client secret key.
+    """
+    provider_id: str
+    client_id: str
+    client_secret: str
+
+
 class Keys(BaseModel):
     """
     A Pydantic model for validating all API keys configurations.
@@ -170,6 +184,8 @@ class Keys(BaseModel):
         UploadIO (UploadIOModel): The UploadIO configuration model.
         Transcription (TranscriptionModel): The Transcription configuration model.
         Papertrail (PapertrailModel): The Papertrail logging configuration model.
+        Telegram (TelegramModel): The Telegram configuration model.
+        Zapier (ZapierModel): The Zapier configuration model.
     """
     # Required keys (tests and active applets)
     Twilio: TwilioModel
@@ -184,4 +200,5 @@ class Keys(BaseModel):
     Transcription: TranscriptionModel
     Papertrail: PapertrailModel
     Telegram: TelegramModel
+    Zapier: ZapierModel
     

--- a/jeeves/permissions/database.py
+++ b/jeeves/permissions/database.py
@@ -30,7 +30,8 @@ class User(BaseModel):
     phone: str
     timezone: str
     use_applets: bool
-    zapier_key: str | None = None
+    zapier_access_token: str | None = None
+    zapier_refresh_token: str | None = None
     telegram_id: int | None = None
 
     @validator("phone")
@@ -82,7 +83,8 @@ class User(BaseModel):
             phone=user["Phone"],
             timezone=user["Timezone"],
             use_applets=user["UseApplets"],
-            zapier_key=user["ZapierKey"],
+            zapier_access_token=user["ZapierAccessToken"],
+            zapier_refresh_token=user["ZapierRefreshToken"],
             telegram_id=user["TelegramID"]
         )
 

--- a/jeeves/permissions/database.py
+++ b/jeeves/permissions/database.py
@@ -65,7 +65,9 @@ class User(BaseModel):
         to refresh it and update the access token both in the User object 
         and in the database.
         """
-        if access_token_expired(values["zapier_access_token"]):
+        token = values["zapier_access_token"]
+
+        if token and access_token_expired(token):
             values["zapier_access_token"] = refresh_zapier_access_token(
                 values["zapier_refresh_token"]
             )

--- a/jeeves/utils.py
+++ b/jeeves/utils.py
@@ -74,7 +74,7 @@ REQUEST_HEADERS: dict[str, str] = {
 
 # ---- Zapier ----
 
-def update_access_token(refresh_token: str) -> str:
+def refresh_zapier_access_token(refresh_token: str) -> str:
     """Generate a new access token."""
     url = "https://nla.zapier.com/oauth/token"
     res = requests.post(

--- a/jeeves/utils.py
+++ b/jeeves/utils.py
@@ -74,9 +74,22 @@ REQUEST_HEADERS: dict[str, str] = {
 
 # ---- Zapier ----
 
+def access_token_expired(access_token: str) -> bool:
+    """Determine if an access token has expired."""
+    url = "https://nla.zapier.com/api/v1/check"
+    res = requests.get(
+        url,
+        headers={
+            "Authorization": f"Bearer {access_token}",
+        },
+    )
+
+    return not res.json()["success"]
+
+
 def refresh_zapier_access_token(refresh_token: str) -> str:
-    """Generate a new access token."""
-    url = "https://nla.zapier.com/oauth/token"
+    """Generate a new access token if the old one is expired."""
+    url = "https://nla.zapier.com/oauth/token/"
     res = requests.post(
         url,
         headers={

--- a/jeeves/utils.py
+++ b/jeeves/utils.py
@@ -1,5 +1,9 @@
 """Utilities for everything."""
+import requests
+
 from functools import wraps
+
+from jeeves.keys import KEYS
 
 
 def app_handler(app_help: str, app_options: dict = {}):
@@ -66,3 +70,25 @@ REQUEST_HEADERS: dict[str, str] = {
     "Accept": "text/html",
     "Referer": "https://www.google.com",
 }
+
+
+# ---- Zapier ----
+
+def update_access_token(refresh_token: str) -> str:
+    """Generate a new access token."""
+    url = "https://nla.zapier.com/oauth/token"
+    res = requests.post(
+        url,
+        headers={
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+        data={
+            "client_id": KEYS.Zapier.client_id,
+            "client_secret": KEYS.Zapier.client_secret,
+            "refresh_token": refresh_token,
+            "grant_type": "refresh_token",
+        }
+    )
+
+    res.raise_for_status()
+    return res.json()["access_token"]

--- a/tests/agency/test_app_gpt.py
+++ b/tests/agency/test_app_gpt.py
@@ -105,11 +105,10 @@ def test_serper_wrapper():
 def test_building_tools(default_options, callback_handlers):
     """Test building the tools. Zapier and text requires auth."""
     # Find a temporary Zapier key
-    users_with_zapier = permissions_db.fetch(
-        {
-            "ZapierKey?contains": "sk"
-        }
-    ).items
+    users_with_zapier = [
+        user for user in permissions_db.fetch().items
+        if user["ZapierAccessToken"]
+    ]
 
     # Make sure Zapier is in there, use first provided phone
     if users_with_zapier:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,7 +47,8 @@ def temporary_user(default_inbound) -> dict[str, str]:
         "Timezone": "EST",
         "UseApplets": True,
         "GenderMale": True,
-        "ZapierKey": None,
+        "ZapierAccessToken": None,
+        "ZapierRefreshToken": None,
         "TelegramID": None
     }
 


### PR DESCRIPTION
Zapier providership. 

Permissions database no longer contains one ZapierKey, rather ZapierAccessToken and ZapierRefreshToken. The User object will automatically validate on instantiation. It will check if the access token is valid. If not, it will use the refresh token to update the access token both in the User object _and_ in the permissions database.

To start, until whitelist:
1. Use the /auth/zapier-start/asdfasdf to redirect a user to NLA setup page, after which they'll get to example.com/?code=aasdfasdf
2. Take the code and GET it to /auth/zapier-handler/userkey to generate and save their access and refresh tokens

They can now use Zapier tools. To update their tools they can go to nla.zapier.com/preritdas/start (soon to become Jeeves).

After whitelisting, we'll use the user key path param for the /zapier-start to construct a redirect uri that contains the user key, that way the user doesnt have to do anything. 