### PR TITLE
Bump to Pydantic v2 and FastAPI supported version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-fastapi==0.98.0  # API
+fastapi==0.100.0-beta1  # API
+pydantic==2.0b2
 deta==1.1.0  # databases throughout
 
 # Server


### PR DESCRIPTION
Pydantic v2 is re-written in Rust. FastAPI v100+ supports Pydantic v2 but maintains support for Pydantic v1. Both are pre-releases currently. 