### PR TITLE
Fix Zapier token refreshing

### DIFF
--- a/jeeves/permissions/database.py
+++ b/jeeves/permissions/database.py
@@ -68,11 +68,17 @@ class User(BaseModel):
         token = values["zapier_access_token"]
 
         if token and access_token_expired(token):
-            values["zapier_access_token"] = refresh_zapier_access_token(
-                values["zapier_refresh_token"]
+            # Refresh the access token and update the refresh token
+            values["zapier_access_token"], values["zapier_refresh_token"] = (
+                refresh_zapier_access_token(values["zapier_refresh_token"])
             )
+
+            # Update the database
             permissions_db.update(
-                {"ZapierAccessToken": values["zapier_access_token"]},
+                {
+                    "ZapierAccessToken": values["zapier_access_token"],
+                    "ZapierRefreshToken": values["zapier_refresh_token"]
+                },
                 values["key"]
             )
 

--- a/jeeves/utils.py
+++ b/jeeves/utils.py
@@ -106,8 +106,12 @@ def access_token_expired(access_token: str) -> bool:
     )
 
 
-def refresh_zapier_access_token(refresh_token: str) -> str:
-    """Generate a new access token if the old one is expired."""
+def refresh_zapier_access_token(refresh_token: str) -> tuple[str, str]:
+    """
+    Generate a new access token if the old one is expired.
+    
+    Returns a tuple of (access_token, refresh_token).
+    """
     res = requests.post(
         url="https://nla.zapier.com/oauth/token/",
         headers={
@@ -122,4 +126,5 @@ def refresh_zapier_access_token(refresh_token: str) -> str:
     )
 
     res.raise_for_status()
-    return res.json()["access_token"]
+    res_json = res.json()
+    return res_json["access_token"], res_json["refresh_token"]


### PR DESCRIPTION
Fixes #98. 

The token refreshing sequence not only creates a new token but creates a new refresh. Code wasn't handling that, so the old refresh token would persist and eventually fail. 

Now, we get both the new access token and new refresh token when refreshing, and the `User` class will both those values in the database.