### PR TITLE
Base agent status code and tests

### DIFF
--- a/api/base_agent.py
+++ b/api/base_agent.py
@@ -1,6 +1,6 @@
 """Protected API access to a userless Jeeves base agent."""
-from pydantic import BaseModel, validator
-from fastapi import APIRouter
+from pydantic import BaseModel
+from fastapi import APIRouter, HTTPException
 
 from jeeves.agency import generate_base_agent_response
 from jeeves.keys import KEYS
@@ -30,11 +30,14 @@ class BaseAgentResponse(BaseModel):
     response: str
 
 
-@router.post("/run", status_code=200)
+@router.post("/run")
 async def base_agent(job: BaseAgentJob) -> BaseAgentResponse:
     """Run a base agent job."""
     # Check the password
     if job.password != KEYS.General.base_agent_password:
-        return BaseAgentResponse(response=f"Incorrect password: {job.password}.")
+        raise HTTPException(
+            status_code=401, 
+            detail=f"Incorrect password: {job.password}."
+        )
 
     return BaseAgentResponse(response=generate_base_agent_response(job.query))

--- a/tests/agency/test_base_agent.py
+++ b/tests/agency/test_base_agent.py
@@ -1,6 +1,18 @@
 """Test the base userless agent."""
+import pytest
+from fastapi.testclient import TestClient
+
+import api
 from jeeves.agency import generate_base_agent_response
 
+
+@pytest.fixture(scope="module")
+def test_client():
+    """Create a test client for the API."""
+    return TestClient(app=api.app)
+
+
+# ---- Test via internal generation function ----
 
 def test_base_agent(mocker, callback_uid):
     """Test getting any response from the base agent."""
@@ -13,3 +25,20 @@ def test_search(mocker, callback_uid):
     mocker.patch("jeeves.agency.uuid.uuid4", return_value=callback_uid)
     assert generate_base_agent_response("weather in washington dc")
  
+
+# ---- Test via client ----
+
+def test_testing_endpoint(test_client):
+    """Test that the testing endpoint is working."""
+    res = test_client.get("/")
+    assert res.status_code == 200
+
+
+def test_wrong_password(test_client):
+    """Test that the wrong password is rejected."""
+    res = test_client.post(
+        "/base-agent/run",
+        json={"password": "wrong", "query": "hi"},
+    )
+
+    assert res.status_code == 401


### PR DESCRIPTION
Fixes #116.

- Update the base agent endpoint so that if the password is rejected, we raise a 401 error with an error message, as opposed to the previous behavior of still returning a 200 status code with the `response` being the error message. This is very misleading...
- Write a test for the base agent using an app test client to check the endpoint's password-checking behavior.