### PR TITLE
Bump FastAPI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fastapi==0.100.0  # API
+fastapi==0.101.1  # API
 deta==1.2.0  # databases throughout
 
 # Server


### PR DESCRIPTION
To version 0.101.1 for better error reporting and improved Pydantic v2 support.