### PR TITLE
Configuration for inbound provider validation

### DIFF
--- a/api/verification.py
+++ b/api/verification.py
@@ -4,6 +4,7 @@ from twilio.request_validator import RequestValidator
 
 from jeeves.texts import BASE_URL
 from jeeves.keys import KEYS
+from jeeves.config import CONFIG
 
 
 # Create Twilio request validator
@@ -19,6 +20,10 @@ async def validate_twilio_request(request: Request, path: str = "") -> bool:
         path (str, optional): Optional path. Provide this for outbound calls as 
             the call id at the end is used when Twilio hashes.
     """
+    # If validation is off, don't validate
+    if not CONFIG.Security.validate_twilio_inbound:
+        return True
+
     if "X-Twilio-Signature" not in request.headers:
         return False
 
@@ -37,6 +42,10 @@ async def validate_twilio_request(request: Request, path: str = "") -> bool:
 
 async def validate_telegram_request(request: Request) -> bool:
     """Use the auth token and request url and form to verify."""
+    # If validation is off, don't validate
+    if not CONFIG.Security.validate_telegram_inbound:
+        return True
+
     if "X-Telegram-Bot-Api-Secret-Token" not in request.headers:
         return False
 

--- a/config.yaml
+++ b/config.yaml
@@ -4,6 +4,10 @@ General:
   dev_phone: "12223334455"  # phone number for auth when running locally
   default_timezone: "US/Eastern"  # default timezone for user
 
+Security:
+  validate_twilio_inbound: true
+  validate_telegram_inbound: true
+
 Weather:
   default_city: McLean  # default city for weather lookup
 

--- a/jeeves/config/models.py
+++ b/jeeves/config/models.py
@@ -43,6 +43,18 @@ class GeneralConfig(BaseModel):
 
         return v
 
+    
+class SecurityConfig(BaseModel):
+    """
+    Security configuration, validation of various services.
+
+    Attributes:
+        validate_twilio_inbound (bool): Whether to validate inbound Twilio requests.
+        validate_telegram_inbound (bool): Whether to validate inbound Telegram requests.
+    """
+    validate_twilio_inbound: bool 
+    validate_telegram_inbound: bool 
+
 
 class WeatherConfig(BaseModel):
     """
@@ -110,6 +122,7 @@ class Config(BaseModel):
         GPT (GPTConfig): GPT configuration.
     """
     General: GeneralConfig
+    Security: SecurityConfig
     Weather: WeatherConfig
     Groceries: GroceriesConfig
     Cocktails: CocktailsConfig


### PR DESCRIPTION
In [config](config.yaml), specify whether to validate inbound pings from various providers. This will allow for easily turning validation on and off if something temporarily stops working from the provider's side.