### PR TITLE
Upgrade remnant Pydantic v1 code

### DIFF
--- a/jeeves/parsing.py
+++ b/jeeves/parsing.py
@@ -3,7 +3,7 @@ Parsing inbound messages for content.
 """
 from typing import Callable
 
-from pydantic import BaseModel, validator
+from pydantic import field_validator, BaseModel
 
 # Project
 from jeeves import applets
@@ -33,7 +33,7 @@ class InboundMessage(BaseModel):
     phone_number: str
     body: str
 
-    @validator("phone_number")
+    @field_validator("phone_number")
     def remove_plus(cls, v):
         """Remove the plus from the phone number."""
         return validate_phone_number(v)

--- a/jeeves/parsing.py
+++ b/jeeves/parsing.py
@@ -3,7 +3,7 @@ Parsing inbound messages for content.
 """
 from typing import Callable
 
-import pydantic
+from pydantic import BaseModel, validator
 
 # Project
 from jeeves import applets
@@ -26,14 +26,14 @@ def _parse_options(options: str) -> dict[str, str]:
     return return_options
 
 
-class InboundMessage(pydantic.BaseModel):
+class InboundMessage(BaseModel):
     """
     Inbound structure to be used .
     """
     phone_number: str
     body: str
 
-    @pydantic.validator("phone_number")
+    @validator("phone_number")
     def remove_plus(cls, v):
         """Remove the plus from the phone number."""
         return validate_phone_number(v)


### PR DESCRIPTION
Old code from applet option parsing was using v1 code, with `validator`. `bump-pydantic` missed it because it was importing `pydantic` and accessing attrs as `pydantic.BaseModel` etc. why was not caught by the CLI.