### PR TITLE
Set base model in config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -19,6 +19,7 @@ Cocktails:
   result_limit: 3  # number of results to return
 
 GPT:
+  base_openai_model: gpt-4
   console_agent: false  # print verbosely to console
 
 Telegram:

--- a/config.yaml
+++ b/config.yaml
@@ -20,6 +20,7 @@ Cocktails:
 
 GPT:
   base_openai_model: gpt-4
+  temperature: 0
   console_agent: false  # print verbosely to console
 
 Telegram:

--- a/config/models.py
+++ b/config/models.py
@@ -95,7 +95,17 @@ class GPTConfig(BaseModel):
     Attributes:
         console_agent (bool): Whether to log to the console.
     """
+    base_openai_model: str
     console_agent: bool
+
+    @field_validator("base_openai_model")
+    def validate_base_openai_model(cls, v):
+        if v not in {"gpt-4", "gpt-3.5-turbo", "gpt-3.5-turbo-16k"}:
+            raise ValueError(
+                "Invalid OpenAI base LLM model provided."
+            )
+
+        return v
 
 
 class TelegramConfig(BaseModel):

--- a/config/models.py
+++ b/config/models.py
@@ -96,6 +96,7 @@ class GPTConfig(BaseModel):
         console_agent (bool): Whether to log to the console.
     """
     base_openai_model: str
+    temperature: int | float
     console_agent: bool
 
     @field_validator("base_openai_model")
@@ -103,6 +104,15 @@ class GPTConfig(BaseModel):
         if v not in {"gpt-4", "gpt-3.5-turbo", "gpt-3.5-turbo-16k"}:
             raise ValueError(
                 "Invalid OpenAI base LLM model provided."
+            )
+
+        return v
+
+    @field_validator("temperature")
+    def validate_temperature(cls, v):
+        if v < 0 or v > 2:
+            raise ValueError(
+                "Temperature must be between 0 and 2."
             )
 
         return v

--- a/jeeves/agency/__init__.py
+++ b/jeeves/agency/__init__.py
@@ -34,7 +34,11 @@ class InternalThoughtZeroShotAgent(ZeroShotAgent):
         return ""
 
 
-llm = ChatOpenAI(model_name="gpt-4", openai_api_key=KEYS.OpenAI.api_key, temperature=0)
+llm = ChatOpenAI(
+    model_name=CONFIG.GPT.base_openai_model, 
+    openai_api_key=KEYS.OpenAI.api_key, 
+    temperature=0
+)
 
 def create_agent_executor(
     toolkit: list[Tool],

--- a/jeeves/agency/__init__.py
+++ b/jeeves/agency/__init__.py
@@ -34,11 +34,14 @@ class InternalThoughtZeroShotAgent(ZeroShotAgent):
         return ""
 
 
+# --- Create the LLM and AgentExecutor ---
+
 llm = ChatOpenAI(
     model_name=CONFIG.GPT.base_openai_model, 
     openai_api_key=KEYS.OpenAI.api_key, 
-    temperature=0
+    temperature=CONFIG.GPT.temperature
 )
+
 
 def create_agent_executor(
     toolkit: list[Tool],


### PR DESCRIPTION
Closes #137. Also allows base model temperature to be configured in config, though it'll probably never change from 0. 

Switching to`gpt-3.5-turbo-16k` will double the context length while sacrificing performance, but could be useful when doing deep iterative web searching. 

Currently this switch would be manual and require redeployment, but eventually there should be an internal model selection mechanism according to the underlying task. 